### PR TITLE
Cascade deletion of Api accross `authorizingForGroup` relation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- iOS: On removing the "home" instance, all instances authentating through this home insance will alse be removed. Cascade deletion of Api accross `authorizingForGroup` relation. #241
+
+## Unreleased
+
 - iOS: Fix for #216: "when 'connecting' there is no 'disconnect' button"
 - macOS: Support for "on demand" added (always on) #220
 - iOS: "On demand" preference removed (now always on) #228

--- a/EduVPN-multiOS/Coordinators/AppCoordinatorError.swift
+++ b/EduVPN-multiOS/Coordinators/AppCoordinatorError.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum AppCoordinatorError: Swift.Error {
+enum AppCoordinatorError: LocalizedError {
     case certificateInvalid
     case certificateNil
     case certificateCommonNameNotFound
@@ -27,7 +27,7 @@ enum AppCoordinatorError: Swift.Error {
     case ovpnTemplate
     case discoverySeqNotIncremented
     
-    var localizedDescription: String {
+    var errorDescription: String {
         switch self {
         case .certificateInvalid:
             return NSLocalizedString("VPN certificate is invalid.", comment: "")

--- a/EduVPN-multiOS/Models/EduVPN.xcdatamodeld/.xccurrentversion
+++ b/EduVPN-multiOS/Models/EduVPN.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>EduVPN 8.xcdatamodel</string>
+	<string>EduVPN 9.xcdatamodel</string>
 </dict>
 </plist>

--- a/EduVPN-multiOS/Models/EduVPN.xcdatamodeld/EduVPN 9.xcdatamodel/contents
+++ b/EduVPN-multiOS/Models/EduVPN.xcdatamodeld/EduVPN 9.xcdatamodel/contents
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15702" systemVersion="19C57" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="9">
+    <entity name="Api" representedClassName="Api" syncable="YES">
+        <attribute name="apiBaseUri" attributeType="String"/>
+        <relationship name="authorizingForGroup" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="InstanceGroup" inverseName="distributedAuthorizationApi" inverseEntity="InstanceGroup"/>
+        <relationship name="authServer" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AuthServer" inverseName="apis" inverseEntity="AuthServer"/>
+        <relationship name="instance" maxCount="1" deletionRule="Nullify" destinationEntity="Instance" inverseName="apis" inverseEntity="Instance"/>
+        <relationship name="profiles" toMany="YES" deletionRule="Cascade" destinationEntity="Profile" inverseName="api" inverseEntity="Profile"/>
+    </entity>
+    <entity name="AuthServer" representedClassName="AuthServer" syncable="YES">
+        <attribute name="authorizationEndpoint" optional="YES" attributeType="String"/>
+        <attribute name="tokenEndpoint" optional="YES" attributeType="String"/>
+        <relationship name="apis" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Api" inverseName="authServer" inverseEntity="Api"/>
+        <relationship name="instances" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Instance" inverseName="authServer" inverseEntity="Instance"/>
+    </entity>
+    <entity name="DisplayName" representedClassName="DisplayName" syncable="YES">
+        <attribute name="displayName" attributeType="String"/>
+        <attribute name="locale" optional="YES" attributeType="String"/>
+        <relationship name="instance" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Instance" inverseName="displayNames" inverseEntity="Instance"/>
+        <relationship name="profile" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Profile" inverseName="displayNames" inverseEntity="Profile"/>
+    </entity>
+    <entity name="Instance" representedClassName="Instance" syncable="YES">
+        <attribute name="baseUri" attributeType="String"/>
+        <attribute name="lastAccessedTimeInterval" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="providerType" optional="YES" attributeType="String"/>
+        <attribute name="publicKey" optional="YES" attributeType="String"/>
+        <relationship name="apis" toMany="YES" deletionRule="Cascade" destinationEntity="Api" inverseName="instance" inverseEntity="Api"/>
+        <relationship name="authServer" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AuthServer" inverseName="instances" inverseEntity="AuthServer"/>
+        <relationship name="displayNames" toMany="YES" deletionRule="Cascade" destinationEntity="DisplayName" inverseName="instance" inverseEntity="DisplayName"/>
+        <relationship name="group" maxCount="1" deletionRule="Nullify" destinationEntity="InstanceGroup" inverseName="instances" inverseEntity="InstanceGroup"/>
+        <relationship name="logos" toMany="YES" deletionRule="Cascade" destinationEntity="Logo" inverseName="instance" inverseEntity="Logo"/>
+    </entity>
+    <entity name="InstanceGroup" representedClassName="InstanceGroup" syncable="YES">
+        <attribute name="authorizationType" optional="YES" attributeType="String"/>
+        <attribute name="discoveryIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="seq" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="distributedAuthorizationApi" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Api" inverseName="authorizingForGroup" inverseEntity="Api"/>
+        <relationship name="instances" toMany="YES" deletionRule="Cascade" destinationEntity="Instance" inverseName="group" inverseEntity="Instance"/>
+    </entity>
+    <entity name="Logo" representedClassName="Logo" syncable="YES">
+        <attribute name="locale" optional="YES" attributeType="String"/>
+        <attribute name="logo" attributeType="String"/>
+        <relationship name="instance" maxCount="1" deletionRule="Nullify" destinationEntity="Instance" inverseName="logos" inverseEntity="Instance"/>
+    </entity>
+    <entity name="Profile" representedClassName="Profile" syncable="YES">
+        <attribute name="profileId" attributeType="String"/>
+        <attribute name="rawVpnStatus" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="api" maxCount="1" deletionRule="Nullify" destinationEntity="Api" inverseName="profiles" inverseEntity="Api"/>
+        <relationship name="displayNames" toMany="YES" deletionRule="Nullify" destinationEntity="DisplayName" inverseName="profile" inverseEntity="DisplayName"/>
+    </entity>
+    <elements>
+        <element name="Api" positionX="-27" positionY="63" width="128" height="118"/>
+        <element name="AuthServer" positionX="-36" positionY="81" width="128" height="105"/>
+        <element name="DisplayName" positionX="-36" positionY="27" width="128" height="105"/>
+        <element name="Instance" positionX="-63" positionY="-18" width="128" height="178"/>
+        <element name="InstanceGroup" positionX="-36" positionY="81" width="128" height="118"/>
+        <element name="Logo" positionX="-54" positionY="0" width="128" height="90"/>
+        <element name="Profile" positionX="-18" positionY="99" width="128" height="120"/>
+    </elements>
+</model>

--- a/EduVPN-multiOS/Networking/ApiService.swift
+++ b/EduVPN-multiOS/Networking/ApiService.swift
@@ -13,13 +13,13 @@ import PromiseKit
 
 import os.log
 
-enum ApiServiceError: Swift.Error {
+enum ApiServiceError: LocalizedError {
     case noAuthState
     case unauthorized
     case urlCreationFailed
     case tokenRefreshFailed(rootCause: Error)
 
-    var localizedDescription: String {
+    var errorDescription: String? {
         switch self {
         case .noAuthState:
             return NSLocalizedString("No stored auth state.", comment: "")

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -2556,7 +2556,7 @@
 				C7FA7ABD23633E68006501E8 /* EduVPN 7.xcdatamodel */,
 				C7FA7ABE23633E68006501E8 /* EduVPN 4.xcdatamodel */,
 			);
-			currentVersion = 4A04CDF5238C71CC00C1D581 /* EduVPN 8.xcdatamodel */;
+			currentVersion = 4A0C8E4E23DAF6B4003C7C8A /* EduVPN 9.xcdatamodel */;
 			path = EduVPN.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		417DD34C1C9EFF60C64C80CB /* Pods-LetsConnect-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LetsConnect-macOS.release.xcconfig"; path = "Target Support Files/Pods-LetsConnect-macOS/Pods-LetsConnect-macOS.release.xcconfig"; sourceTree = "<group>"; };
 		4A01329921CDA2C2009B8B02 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Main.strings; sourceTree = "<group>"; };
 		4A04CDF5238C71CC00C1D581 /* EduVPN 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "EduVPN 8.xcdatamodel"; sourceTree = "<group>"; };
+		4A0C8E4E23DAF6B4003C7C8A /* EduVPN 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "EduVPN 9.xcdatamodel"; sourceTree = "<group>"; };
 		4A1140831F78490C00D61100 /* VPNConnectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNConnectionViewController.swift; sourceTree = "<group>"; };
 		4A1163292370539E00577755 /* Crypto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Crypto.swift; path = EduVPN/Models/Crypto.swift; sourceTree = SOURCE_ROOT; };
 		4A2803D81FA6867D00FA895C /* CustomProviderInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomProviderInputViewController.swift; sourceTree = "<group>"; };
@@ -2545,6 +2546,7 @@
 		C7FA7AB723633E68006501E8 /* EduVPN.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				4A0C8E4E23DAF6B4003C7C8A /* EduVPN 9.xcdatamodel */,
 				4A04CDF5238C71CC00C1D581 /* EduVPN 8.xcdatamodel */,
 				C7FA7AB823633E68006501E8 /* EduVPN 6.xcdatamodel */,
 				C7FA7AB923633E68006501E8 /* EduVPN 3.xcdatamodel */,


### PR DESCRIPTION
Fixes #236 

Deleting an InstanceGroup cascades towards all grouped Instances.

So when we cascade across the relation `authorizingForGroup` on an API we delete all grouped configurations when we delete the HOME country.

@johankool What do you think? I will test my assumptions once I have fresh eduROAM credentials.
@efef Do we need to warn the user about the "bigger" deletion the user is about to do?