### PR TITLE
Applied check when considering `noProfiles` situations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - macOS: Fixed resizing issue on connection view  #192
 - iOS: Fix for app when no profiles configured. App should move to "add" screen.
 - iOS: Fix crash on iOS 12 due to CryptoKit Linking. #238
+- iOS/Mac: Fix double pushing of a screen on initial start of app when no instances are loaded yet.
 
 ## 2.1.1 (2020-01-06)
 

--- a/EduVPN-macOS/Controllers/ProvidersViewController.swift
+++ b/EduVPN-macOS/Controllers/ProvidersViewController.swift
@@ -10,7 +10,7 @@ import Cocoa
 import os.log
 import Alamofire
 
-/// Used to display configure providers (when providerType == .unknown) and to select a specific provider to add.
+/// Used to display configure providers (when providerType == .unknown aka. configuredForInstancesDisplay)  and to select a specific provider to add.
 class ProvidersViewController: NSViewController {
     
     weak var delegate: ProvidersViewControllerDelegate?
@@ -32,6 +32,11 @@ class ProvidersViewController: NSViewController {
     var selectingConfig: Bool = false
     
     var providerType: ProviderType = .unknown
+
+    var configuredForInstancesDisplay: Bool {
+        return providerType == .unknown
+    }
+    
     private var started = false
     
     private lazy var fetchedResultsController: FetchedResultsController<Instance> = {
@@ -85,7 +90,7 @@ class ProvidersViewController: NSViewController {
         
         do {
             try fetchedResultsController.performFetch()
-            if providerType == .unknown && rows.isEmpty {
+            if configuredForInstancesDisplay && rows.isEmpty {
                 delegate?.addProvider(providersViewController: self, animated: false)
             }
         } catch {

--- a/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/ProvidersViewControllerDelegate.swift
+++ b/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/ProvidersViewControllerDelegate.swift
@@ -68,7 +68,7 @@ extension AppCoordinator: ProvidersViewControllerDelegate {
     func didSelect(instance: Instance, providersViewController: ProvidersViewController) {
         os_log("Did select provider type: %{public}@ instance: %{public}@", log: Log.general, type: .info, "\(providersViewController.providerType)", "\(instance)")
 
-        if providersViewController.providerType == .unknown {
+        if providersViewController.configuredForInstancesDisplay {
             do {
                 persistentContainer.performBackgroundTask { (context) in
                     if let backgroundInstance = context.object(with: instance.objectID) as? Instance {

--- a/EduVPN/ViewControllers/ProvidersViewController.swift
+++ b/EduVPN/ViewControllers/ProvidersViewController.swift
@@ -83,6 +83,10 @@ class ProvidersViewController: UITableViewController {
     var selectingConfig: Bool = false
     
     var providerType: ProviderType = .unknown
+
+    var configuredForInstancesDisplay: Bool {
+        return providerType == .unknown
+    }
     
     private lazy var fetchedResultsController: FetchedResultsController<Instance> = {
         let fetchRequest = NSFetchRequest<Instance>()
@@ -128,7 +132,7 @@ class ProvidersViewController: UITableViewController {
         
         refresh()
 
-        if fetchedResultsController.count == 0 { // swiftlint:disable:this empty_count
+        if configuredForInstancesDisplay && fetchedResultsController.count == 0 { // swiftlint:disable:this empty_count
             delegate?.noProfiles(providerTableViewController: self)
         }
     }
@@ -146,10 +150,10 @@ class ProvidersViewController: UITableViewController {
 
         tableView.tableFooterView = UIView()
 
-        if Config.shared.predefinedProvider != nil, providerType == .unknown {
+        if Config.shared.predefinedProvider != nil, configuredForInstancesDisplay {
             // There is a predefined provider. So do not allow adding.
             navigationItem.rightBarButtonItems = [settingsButton]
-        } else if providerType == .unknown {
+        } else if configuredForInstancesDisplay {
             navigationItem.rightBarButtonItems = [settingsButton, addButton]
         } else {
             navigationItem.rightBarButtonItems = []
@@ -226,7 +230,7 @@ extension ProvidersViewController {
     }
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return providerType == .unknown
+        return configuredForInstancesDisplay
     }
     
     override func tableView(_ tableView: UITableView,

--- a/EduVPN/ViewControllers/ProvidersViewController.swift
+++ b/EduVPN/ViewControllers/ProvidersViewController.swift
@@ -84,6 +84,7 @@ class ProvidersViewController: UITableViewController {
     
     var providerType: ProviderType = .unknown
 
+    /// When `providerType == .unknown` the ProvidersViewController is supposed to display only instances that have been configured.
     var configuredForInstancesDisplay: Bool {
         return providerType == .unknown
     }


### PR DESCRIPTION
Introduced calculated variable to clarify the meaning of `providerType == .unknown` and applied this check when considering `noProfiles` situations.