### PR TITLE
Fix reconnect issue by preventing a new NESMVPNSession stuck in limbo after disconnect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - iOS: Fix crash on iOS 12 due to CryptoKit Linking. #238
 - iOS/Mac: Fix double pushing of a screen on initial start of app when no instances are loaded yet.
 - iOS/Mac: Update to TunnelKit 2.2.3
+- macOS: Fix reconnect issue by preventing a new NESMVPNSession stuck in limbo after disconnect
 
 ## 2.1.1 (2020-01-06)
 

--- a/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
+++ b/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
@@ -186,6 +186,16 @@ class VPNConnectionViewController: NSViewController {
     private lazy var decoder = JSONDecoder()
     
     func updateConnectionInfo() {
+        if status == .disconnecting || status == .disconnected || status == .invalid {
+            ipv4AddressField.stringValue = ""
+            ipv6AddressField.stringValue = ""
+            durationLabel.stringValue = ""
+            inBytesLabel.stringValue = ""
+            outBytesLabel.stringValue = ""
+            
+            return
+        }
+        
         guard
             let vpn = providerManagerCoordinator.currentManager?.connection as? NETunnelProviderSession,
             profile.isActiveConfig

--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -229,7 +229,6 @@ class TunnelProviderManagerCoordinator: Coordinator {
                 return nil
             }, completionHandler: { error in
                 self.currentManager?.connection.stopVPNTunnel()
-                self.currentManager = NETunnelProviderManager()
                 resolver.resolve(error)
             })
         })


### PR DESCRIPTION
After a disconnect a Connection Info update (updateConnectionInfo in VPNConnectionViewController) would start a new NETunnelProviderSession getting stuck in limbo, which causes an "Extension died unexpectedly" error after a timeout of 20 seconds and preventing a new connect. This fix just empties the Connection Info when disconnecting and returns without calling a new NETunnelProviderSession.

Removing "self.currentManager = NETunnelProviderManager()" prevents a NEVPNStatus of "invalid" and is not necessary anymore with this fix.