### PR TITLE
Prevent reconnect issue (iOS)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - iOS/Mac: More detailed errors on invalid status codes. #263 #232
+- iOS: Prevent NETunnelProviderSession initialization after disconnect
 
 ## 2.2 (2020-05-01)
 

--- a/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
+++ b/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
@@ -186,7 +186,7 @@ class VPNConnectionViewController: NSViewController {
     private lazy var decoder = JSONDecoder()
     
     func updateConnectionInfo() {
-        if status == .disconnecting || status == .disconnected || status == .invalid {
+        if status != .connected {
             ipv4AddressField.stringValue = ""
             ipv6AddressField.stringValue = ""
             durationLabel.stringValue = ""

--- a/EduVPN/ViewControllers/VPNConnectionViewController.swift
+++ b/EduVPN/ViewControllers/VPNConnectionViewController.swift
@@ -185,6 +185,14 @@ class VPNConnectionViewController: UIViewController {
     }
 
     func updateConnectionInfo() {
+        if status != .connected {
+            durationLabel.text = ""
+            inBytesLabel.text = ""
+            outBytesLabel.text = ""
+            
+            return
+        }
+        
         guard
             let vpn = providerManagerCoordinator.currentManager?.connection as? NETunnelProviderSession,
             profile.isActiveConfig


### PR DESCRIPTION
Like on macOS, this fix prevents a possible reconnect issue on iOS, a new NETunnelProviderSession shouldn't be initialised after a disconnect.
Connection Info should only be updated when in a connected state, a change for macOS in regard to this is included in this commit too.