### PR TITLE
Preserve log across tunnel invocations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- iOS/Mac: Preserve tunnel log across the previous tunnel invocation
 
 ## 2.2 (2020-05-08)
 

--- a/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
+++ b/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
@@ -249,8 +249,6 @@ class VPNConnectionViewController: NSViewController {
     }
     
     // MARK: - Log
-    
-    @IBOutlet weak var logTextView: NSTextField!
 
     private func connectionLogPathDir() throws -> URL {
         guard let logDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { throw LogFileError.pathCreationFailed }

--- a/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
+++ b/EduVPN-macOS/Controllers/VPNConnectionViewController.swift
@@ -94,6 +94,7 @@ class VPNConnectionViewController: NSViewController {
         
         self.status = status
         updateButton()
+        updateViewLogButton()
     }
     
     func updateButton() {
@@ -250,6 +251,8 @@ class VPNConnectionViewController: NSViewController {
     
     // MARK: - Log
 
+    @IBOutlet weak var viewLogButton: NSButton!
+
     private func connectionLogPathDir() throws -> URL {
         guard let logDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { throw LogFileError.pathCreationFailed }
         return logDirPath.appendingPathComponent("tmp")
@@ -291,7 +294,12 @@ class VPNConnectionViewController: NSViewController {
             os_log("Couldn't view log error: %{public}@", log: Log.general, type: .error, "\(error)")
         }
     }
-    
+
+    private func updateViewLogButton() {
+        // Whether we can view the log or not depends on the connection status
+        viewLogButton.isEnabled = providerManagerCoordinator.canLoadLog()
+    }
+
     // MARK: - Other
     
     @IBOutlet var statisticsBox: NSBox!

--- a/EduVPN-macOS/Resources/Base.lproj/Main.storyboard
+++ b/EduVPN-macOS/Resources/Base.lproj/Main.storyboard
@@ -1321,6 +1321,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
                         <outlet property="spinner" destination="HSo-Og-0y9" id="Zgf-Sd-zdc"/>
                         <outlet property="statisticsBox" destination="gLA-m0-Zbt" id="YfW-ne-p5G"/>
                         <outlet property="statusImage" destination="ico-ME-n8x" id="MZ3-Xz-iF1"/>
+                        <outlet property="viewLogButton" destination="Yjd-E0-Eam" id="zFG-jh-MAV"/>
                     </connections>
                 </viewController>
                 <customObject id="FhF-Bg-4GD" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -260,6 +260,7 @@ class TunnelProviderManagerCoordinator: Coordinator {
     
     func loadLog(completion: ((String) -> Void)? = nil) {
         guard let session = currentManager?.connection as? NETunnelProviderSession else {
+            completion?("")
             return
         }
 
@@ -268,6 +269,7 @@ class TunnelProviderManagerCoordinator: Coordinator {
             // Ask the tunnel process for the log
             try? session.sendProviderMessage(OpenVPNTunnelProvider.Message.requestLog.data) { data in
                 guard let data = data, let log = String(data: data, encoding: .utf8) else {
+                    completion?("")
                     return
                 }
                 completion?(log)

--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -125,6 +125,7 @@ class TunnelProviderManagerCoordinator: Coordinator {
                 self.configureVPN({ _ in
                     var builder = OpenVPNTunnelProvider.ConfigurationBuilder(sessionConfiguration: configBuilder.build())
                     builder.masksPrivateData = false
+                    builder.shouldDebug = true
 
                     #if DEBUG
                     #else
@@ -325,7 +326,6 @@ class TunnelProviderManagerCoordinator: Coordinator {
                 if let prot = man.protocolConfiguration as? NETunnelProviderProtocol {
                     if prot.providerBundleIdentifier == self.vpnBundle {
                         //    os_log("provider config: \(prot.providerConfiguration)", log: Log.general, type: .info)
-                        
                         manager = man
                         break
                     }

--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -283,15 +283,9 @@ class TunnelProviderManagerCoordinator: Coordinator {
                 return
             }
             completion?((try? String(contentsOf: debugLogURL)) ?? "")
-        case .disconnecting:
-            // The process might be writing to the log file, so it might not be
-            // safe to access it now.
-            fallthrough
-        case .connecting:
-            // The log will only have stale info pertaining to the previous
-            // connections.
-            fallthrough
         default:
+            // When disconnecting, the tunnel process might be writing to the log.
+            // When connecting, the log would contain only on the previous connection.
             completion?("")
         }
     }

--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -295,6 +295,19 @@ class TunnelProviderManagerCoordinator: Coordinator {
             completion?("")
         }
     }
+
+    func canLoadLog() -> Bool {
+        guard let session = currentManager?.connection as? NETunnelProviderSession else {
+            return false
+        }
+
+        switch session.status {
+        case .connected, .disconnected, .reasserting:
+            return true
+        default:
+            return false
+        }
+    }
     
     func configureVPN(_ configure: @escaping (NETunnelProviderManager) -> NETunnelProviderProtocol?,
                       completionHandler: @escaping (Error?) -> Void) {

--- a/EduVPN/ViewControllers/VPNConnectionViewController.swift
+++ b/EduVPN/ViewControllers/VPNConnectionViewController.swift
@@ -89,6 +89,7 @@ class VPNConnectionViewController: UIViewController {
 
         self.status = status
         updateButton()
+        updateDisplayLogButtonEnabled()
     }
 
     func updateButton() {
@@ -234,6 +235,11 @@ class VPNConnectionViewController: UIViewController {
         refreshLog.toggle()
 
         buttonDisplayLog.titleLabel?.text = refreshLog ? NSLocalizedString("Stop refreshing log", comment: "") : NSLocalizedString("Display log", comment: "")
+    }
+
+    private func updateDisplayLogButtonEnabled() {
+        // Whether we can view the log or not depends on the connection status
+        buttonDisplayLog.isEnabled = providerManagerCoordinator.canLoadLog()
     }
 
     // MARK: - Other

--- a/EduVPN/ViewControllers/VPNConnectionViewController.swift
+++ b/EduVPN/ViewControllers/VPNConnectionViewController.swift
@@ -234,7 +234,10 @@ class VPNConnectionViewController: UIViewController {
     @IBAction func displayLogClicked(_ sender: Any) {
         refreshLog.toggle()
 
-        buttonDisplayLog.titleLabel?.text = refreshLog ? NSLocalizedString("Stop refreshing log", comment: "") : NSLocalizedString("Display log", comment: "")
+        let buttonTitle = refreshLog ?
+            NSLocalizedString("Stop refreshing log", comment: "") :
+            NSLocalizedString("Display log", comment: "")
+        buttonDisplayLog.setTitle(buttonTitle, for: .normal)
     }
 
     private func updateDisplayLogButtonEnabled() {


### PR DESCRIPTION
Fixes #247 

  - Tunnel log lasts across the last *two* invocations. Done using an option in TunnelKit.
  - Tunnel log can be seen even when tunnel is disconnected. Previously, the log was shown as empty unless the tunnel was connected.
  - Tunnel log can't be seen when connecting or disconnecting
