### PR TITLE
Refactor TunnelProviderManagerCoordinator by leveraging PromiseKit

### DIFF
--- a/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/ConnectionsTableViewControllerDelegate.swift
+++ b/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/ConnectionsTableViewControllerDelegate.swift
@@ -24,11 +24,10 @@ extension AppCoordinator: ConnectionsTableViewControllerDelegate {
         if let currentProfileUuid = profile.uuid, currentProfileUuid.uuidString == UserDefaults.standard.configuredProfileId {
             _ = showConnectionViewController(for: profile)
         } else {
-            _ = tunnelProviderManagerCoordinator.disconnect()
-                .recover { _ in self.tunnelProviderManagerCoordinator.configure(profile: profile) }
-                .then { _ -> Promise<Void> in
+            _ = tunnelProviderManagerCoordinator.configure(profile: profile)
+                .ensure {
                     self.providersViewController.tableView.reloadData()
-                    return self.showConnectionViewController(for: profile)
+                    _ = self.showConnectionViewController(for: profile)
                 }
         }
     }

--- a/EduVPN-multiOS/Coordinators/AppCoordinator+ViewControllers.swift
+++ b/EduVPN-multiOS/Coordinators/AppCoordinator+ViewControllers.swift
@@ -168,7 +168,7 @@ extension AppCoordinator {
         #elseif os(macOS)
         return presentationPromise
             .then { self.tunnelProviderManagerCoordinator.configure(profile: profile) }
-            .then { self.tunnelProviderManagerCoordinator.connect() }
+            .then { $0.connect() }
         #endif
     }
 


### PR DESCRIPTION
Functionality remains unchanged. Line count has slightly *increased* 😞.

Possible follow-ups:
 - get rid of `TunnelProviderManagerCoordinator.currentManager`?
 - get rid of `UserDefaults.standard.configuredProfileId`?
