### PR TITLE
TunnelKit: Don't disconnect when network goes down

### DIFF
--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -181,12 +181,8 @@ class TunnelProviderManagerCoordinator: Coordinator {
                 return
             }
             
-            // Always enable "on demand"
-            currentManager.isOnDemandEnabled = true
-            let rule = NEOnDemandRuleConnect()
-            rule.interfaceTypeMatch = .any
-            currentManager.onDemandRules = [rule]
-            
+            currentManager.isOnDemandEnabled = false
+
             currentManager.saveToPreferences(completionHandler: { error in
                 if let error = error {
                     os_log("error saveToPreferences tunnel: %{public}@", log: Log.general, type: .error, error.localizedDescription)

--- a/EduVPNTunnelExtension-macOS/PacketTunnelProvider.swift
+++ b/EduVPNTunnelExtension-macOS/PacketTunnelProvider.swift
@@ -6,4 +6,8 @@
 import TunnelKit
 
 class PacketTunnelProvider: OpenVPNTunnelProvider {
+    override init() {
+        super.init()
+        super.setWaitForLinkAvailabilityAfterLinkFailure(enabled: true)
+    }
 }

--- a/EduVPNTunnelExtension/PacketTunnelProvider.swift
+++ b/EduVPNTunnelExtension/PacketTunnelProvider.swift
@@ -6,4 +6,8 @@
 import TunnelKit
 
 class PacketTunnelProvider: OpenVPNTunnelProvider {
+    override init() {
+        super.init()
+        super.setWaitForLinkAvailabilityAfterLinkFailure(enabled: true)
+    }
 }


### PR DESCRIPTION
This is a proof-of-concept that shows how TunnelKit can be modified to keep the tunnel process running when the network goes down, and wait for the network to come back up. The tunnel process uses `NWPathMonitor` to figure out when the network is back.

Consequently, connect on demand is turned off.

Being a draft PR, this only modifies the in-repo version of TunnelKit. The Podfile is unchanged.