### PR TITLE
Fix bug introduced during the refactoring of TunnelProviderManagerCoordinator

### DIFF
--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -200,8 +200,12 @@ extension NETunnelProviderManager {
     }
 
     func disconnect() -> Promise<Void> {
-        return setOnDemand(enabled: false)
-            .map { self.stopTunnel() }
+        if isStatusActive(connection.status) {
+            return setOnDemand(enabled: false)
+                .map { self.stopTunnel() }
+        } else {
+            return Promise.value(())
+        }
     }
 }
 


### PR DESCRIPTION
Avoid saving on-demand on an invalid tunnel provider manager