### PR TITLE
Remove unrecognized debugLogFormat

### DIFF
--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -410,7 +410,6 @@ private func getTunnelProviderProtocol(vpnBundle: String, appGroup: String,
     var providerConfigBuilder = OpenVPNTunnelProvider.ConfigurationBuilder(sessionConfiguration: configBuilder.build())
     providerConfigBuilder.masksPrivateData = false
     providerConfigBuilder.shouldDebug = true
-    providerConfigBuilder.debugLogFormat = "$HH:mm:ss$d $L - $M"
 
     let providerConfig = providerConfigBuilder.build()
     let tunnelProviderProtocolConfig = try providerConfig.generatedTunnelProtocol(


### PR DESCRIPTION
Fixes the log having no usable timestamp after PR #274

Looks like we've been setting the wrong log format all along, which TunnelKit was ignoring previously because we weren't using `shouldDebug = true`.