### PR TITLE
Fix assertion failure when popping view controllers

### DIFF
--- a/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/CustomProviderInputViewControllerDelegate.swift
+++ b/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/CustomProviderInputViewControllerDelegate.swift
@@ -38,17 +38,7 @@ extension AppCoordinator: CustomProviderInputViewControllerDelegate {
             }
         }).then { instance -> Promise<Void> in
             let instance = self.persistentContainer.viewContext.object(with: instance.objectID) as! Instance //swiftlint:disable:this force_cast
-            return self.refresh(instance: instance).then {_ -> Promise<Void> in
-                #if os(iOS)
-                self.popToRootViewController()
-                #elseif os(macOS)
-                self.popToRootViewController(animated: false, completionHandler: {
-                    self.dismissViewController()
-                })
-                #endif
-
-                return Promise.value(())
-            }
+            return self.refresh(instance: instance)
         }.recover { error in
                 let error = error as NSError
                 self.showError(error)

--- a/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/ProvidersViewControllerDelegate.swift
+++ b/EduVPN-multiOS/Coordinators/AppCoordinator Delegates/ProvidersViewControllerDelegate.swift
@@ -90,10 +90,12 @@ extension AppCoordinator: ProvidersViewControllerDelegate {
             // Move this to pull to refresh?
             refresh(instance: instance).then { _ -> Promise<Void> in
                 #if os(iOS)
+                // Both profiles VC and providers VC are pushed onto the navigation stack
                 self.popToRootViewController()
                 #elseif os(macOS)
-                // TODO: It is unclear to me why iOS pops to root here. For macOS dismiss seems wrong.
-                // self.dismissViewController()
+                // Profiles VC is presented, and providers VC is pushed onto the presented VC.
+                // So we just dismiss the presented VC.
+                self.dismissViewController()
                 #endif
                 return .value(())
             }.recover { error in

--- a/EduVPN-multiOS/Coordinators/AppCoordinator+Repositories.swift
+++ b/EduVPN-multiOS/Coordinators/AppCoordinator+Repositories.swift
@@ -70,10 +70,6 @@ extension AppCoordinator {
                 NotificationCenter.default.post(name: Notification.Name.InstanceRefreshed, object: self)
                 return self.hideActivityIndicator()
             }.ensureThen {
-                // TODO: See also ProvidersViewControllerDelegate didSelect(instance:, providersViewController: )
-                #if os(macOS)
-                self.dismissViewController()
-                #endif
                 return .value(())
             }
     }

--- a/EduVPN/ViewControllers/CustomProviderInputViewController.swift
+++ b/EduVPN/ViewControllers/CustomProviderInputViewController.swift
@@ -16,7 +16,7 @@ class CustomProviderInputViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         // Do any additional setup after loading the view.
         keyboardWrapper = KeyboardWrapper(delegate: self)
         
@@ -36,6 +36,9 @@ class CustomProviderInputViewController: UIViewController {
         guard let url = urlFromInput() else { return }
         self.view.endEditing(false)
         delegate?.connect(url: url)
+            .done { _ in
+                self.navigationController?.popToRootViewController(animated: true)
+            }.cauterize()
     }
     
     private func urlFromInput() -> URL? {
@@ -50,6 +53,9 @@ extension CustomProviderInputViewController: UITextFieldDelegate {
         guard let url = urlFromInput() else { return true }
         self.view.endEditing(false)
         delegate?.connect(url: url)
+            .done { _ in
+                self.navigationController?.popToRootViewController(animated: true)
+            }.cauterize()
         return true
     }
 }


### PR DESCRIPTION
There's an assertion failure in macOS when we do either of these:

 1. Select a provider, click on _Connect_, authorize, wait
 2. Add a custom provider by URL, authorize, wait

Both are related to assert()s in macOS code related to popping view controllers. The failure happens only in debug mode. It won't happen in what we submit to the App Store.

This PR fixes the failure by:

- Removing UI code from `refresh(instance:)` and `connect(url:)`
- Adding UI code for dismissing views after adding a custom provider (iOS)

The assertions themselves are correct, so they are retained.

Tested for the following scenarios in both macOS and iOS: 

  - Adding secure internet provider
  - Adding institute access provider
  - Adding custom provider by URL
  - Selecting a provider and connecting
