### PR TITLE
iOS: Start spinner animation on reasserting too

### DIFF
--- a/EduVPN/ViewControllers/VPNConnectionViewController.swift
+++ b/EduVPN/ViewControllers/VPNConnectionViewController.swift
@@ -235,7 +235,7 @@ class VPNConnectionViewController: UIViewController {
     }
 
     func updateSpinner() {
-        if isVPNBeingConfigured || status == .connecting || status == .disconnecting {
+        if isVPNBeingConfigured || status == .connecting || status == .disconnecting || status == .reasserting {
             self.spinner?.startAnimating()
         } else {
             self.spinner?.stopAnimating()


### PR DESCRIPTION
Follow-up to PR #304.

Like showing the spinner on macOS when reasserting, do the same for iOS.
