### PR TITLE
TunnelProviderManagerCoordinator: Disconnect should always disable on-demand

### DIFF
--- a/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
+++ b/EduVPN-multiOS/Coordinators/TunnelProviderManagerCoordinator.swift
@@ -205,7 +205,7 @@ extension NETunnelProviderManager {
     }
 
     func disconnect() -> Promise<Void> {
-        if isStatusActive(connection.status) {
+        if protocolConfiguration != nil {
             return setOnDemand(enabled: false)
                 .map { self.stopTunnel() }
         } else {


### PR DESCRIPTION
Follow-up to PR #304.

Previously, in case the tunnel is down with on-demand set (say the network is down), then the button shows "Disconnect", but wouldn't do anything. This PR fixes that.
