### PR TITLE
Modify local TunnelKit's handling of hasBetterPath using NWPathMonitor

### DIFF
--- a/EduVPN-redesign/Controllers/PreferencesViewController.swift
+++ b/EduVPN-redesign/Controllers/PreferencesViewController.swift
@@ -32,6 +32,7 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
     @IBOutlet weak var showInStatusBarCheckbox: NSButton!
     @IBOutlet weak var showInDockCheckbox: NSButton!
     @IBOutlet weak var launchAtLoginCheckbox: NSButton!
+    @IBOutlet weak var assistPathUpgradingCheckbox: NSButton!
 
     func initializeParameters(_ parameters: Parameters) {
         guard self.parameters == nil else {
@@ -46,11 +47,13 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
         let isShowInStatusBarEnabled = userDefaults.showInStatusBar
         let isShowInDockEnabled = userDefaults.showInDock
         let isLaunchAtLoginEnabled = userDefaults.launchAtLogin
+        let isAssistPathUpgradingEnabled = userDefaults.assistPathUpgradingWithPathMonitor
 
         useTCPOnlyCheckbox.state = isForceTCPEnabled ? .on : .off
         showInStatusBarCheckbox.state = isShowInStatusBarEnabled ? .on : .off
         showInDockCheckbox.state = isShowInDockEnabled ? .on : .off
         launchAtLoginCheckbox.state = isLaunchAtLoginEnabled ? .on : .off
+        assistPathUpgradingCheckbox.state = isAssistPathUpgradingEnabled ? .on : .off
 
         // If one of "Show in status bar" or "Show in Dock" is off,
         // disable editing the other
@@ -65,6 +68,11 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
     @IBAction func useTCPOnlyCheckboxClicked(_ sender: Any) {
         let isUseTCPOnlyChecked = (useTCPOnlyCheckbox.state == .on)
         UserDefaults.standard.forceTCP = isUseTCPOnlyChecked
+    }
+
+    @IBAction func assistPathUpgradingCheckboxClicked(_ sender: Any) {
+        let isChecked = (assistPathUpgradingCheckbox.state == .on)
+        UserDefaults.standard.assistPathUpgradingWithPathMonitor = isChecked
     }
 
     @IBAction func viewLogClicked(_ sender: Any) {

--- a/EduVPN-redesign/Helpers/UserDefaults+Preferences.swift
+++ b/EduVPN-redesign/Helpers/UserDefaults+Preferences.swift
@@ -12,6 +12,8 @@ extension UserDefaults {
     private static let showInDockKey = "showInDock"
     private static let launchAtLoginKey = "launchAtLogin"
 
+    private static let assistPathUpgradingWithPathMonitorKey = "assistPathUpgradingWithPathMonitor"
+
     var forceTCP: Bool {
         get { // swiftlint:disable:this implicit_getter
             return bool(forKey: Self.forceTCPDefaultsKey)
@@ -51,6 +53,15 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Self.launchAtLoginKey)
+        }
+    }
+
+    var assistPathUpgradingWithPathMonitor: Bool {
+        get { // swiftlint:disable:this implicit_getter
+            return bool(forKey: Self.assistPathUpgradingWithPathMonitorKey)
+        }
+        set {
+            set(newValue, forKey: Self.assistPathUpgradingWithPathMonitorKey)
         }
     }
 }

--- a/EduVPN-redesign/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN-redesign/Resources/Mac/Base.lproj/Main.storyboard
@@ -529,13 +529,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="1269" height="194"/>
+                                <rect key="frame" x="20" y="20" width="1305" height="174"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="1269" height="194"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="1305" height="174"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="1269" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="1305" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -764,11 +764,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="180" y="217" width="90" height="589"/>
+                                        <rect key="frame" x="180" y="197" width="90" height="609"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="172" width="454" height="33"/>
+                                        <rect key="frame" x="-2" y="152" width="454" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -776,7 +776,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="120" width="450" height="40"/>
+                                        <rect key="frame" x="0.0" y="100" width="450" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -790,12 +790,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="209" y="76" width="32" height="32"/>
+                                        <rect key="frame" x="209" y="56" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="0.0" y="0.0" width="450" height="64"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="450" height="44"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="450" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="450" height="44"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">
@@ -1476,10 +1476,10 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yI9-CM-5gZ">
-                                <rect key="frame" x="20" y="20" width="410" height="410"/>
+                                <rect key="frame" x="20" y="20" width="410" height="441"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rjv-VU-vqt">
-                                        <rect key="frame" x="-2" y="377" width="414" height="33"/>
+                                        <rect key="frame" x="-2" y="408" width="414" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Preferences" id="8ia-lI-dqX">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1487,10 +1487,10 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="GMI-07-EVu">
-                                        <rect key="frame" x="0.0" y="358" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="389" width="410" height="5"/>
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bZ6-la-8zq">
-                                        <rect key="frame" x="-2" y="327" width="175" height="19"/>
+                                        <rect key="frame" x="-2" y="358" width="175" height="19"/>
                                         <buttonCell key="cell" type="check" title="Connect using TCP only" bezelStyle="regularSquare" imagePosition="left" inset="2" id="t0F-zx-2Sp">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1500,7 +1500,7 @@ Gw
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="F1W-bg-sSw">
-                                        <rect key="frame" x="16" y="275" width="396" height="38"/>
+                                        <rect key="frame" x="16" y="306" width="396" height="38"/>
                                         <textFieldCell key="cell" selectable="YES" title="Changes to this option will take effect from the next connection onwards" id="rqy-tm-oLB">
                                             <font key="font" size="14" name="OpenSans-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1508,10 +1508,10 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Xq3-ya-gMs">
-                                        <rect key="frame" x="0.0" y="256" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="287" width="410" height="5"/>
                                     </box>
                                     <customView horizontalHuggingPriority="100" verticalHuggingPriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="HhY-AU-L8g" userLabel="Connect log container">
-                                        <rect key="frame" x="0.0" y="210" width="410" height="32"/>
+                                        <rect key="frame" x="0.0" y="241" width="410" height="32"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="aEb-MM-aWn">
                                                 <rect key="frame" x="-2" y="7" width="320" height="19"/>
@@ -1542,10 +1542,10 @@ Gw
                                         </constraints>
                                     </customView>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="NeP-ch-ODB">
-                                        <rect key="frame" x="0.0" y="191" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="222" width="410" height="5"/>
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BB1-ZH-rOd">
-                                        <rect key="frame" x="-2" y="160" width="141" height="19"/>
+                                        <rect key="frame" x="-2" y="191" width="141" height="19"/>
                                         <buttonCell key="cell" type="check" title="Show in menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vXs-mm-f1r">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1555,7 +1555,7 @@ Gw
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5mk-S8-qPc">
-                                        <rect key="frame" x="-2" y="129" width="110" height="19"/>
+                                        <rect key="frame" x="-2" y="160" width="110" height="19"/>
                                         <buttonCell key="cell" type="check" title="Show in Dock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lxj-3d-HUJ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1565,10 +1565,10 @@ Gw
                                         </connections>
                                     </button>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="kvx-08-oca">
-                                        <rect key="frame" x="0.0" y="112" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="143" width="410" height="5"/>
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0ht-iC-Bc3">
-                                        <rect key="frame" x="-2" y="81" width="122" height="19"/>
+                                        <rect key="frame" x="-2" y="112" width="122" height="19"/>
                                         <buttonCell key="cell" type="check" title="Launch at login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="gLp-0o-Odu">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1578,8 +1578,18 @@ Gw
                                         </connections>
                                     </button>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="STQ-ap-m2r">
-                                        <rect key="frame" x="0.0" y="64" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="95" width="410" height="5"/>
                                     </box>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wtN-ul-9kg">
+                                        <rect key="frame" x="-2" y="64" width="384" height="19"/>
+                                        <buttonCell key="cell" type="check" title="Assist path upgrading with path monitor (experimental)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="QK5-oe-g2a">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" size="14" name="OpenSans-Regular"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="assistPathUpgradingCheckboxClicked:" target="46m-sg-SJs" id="Acw-P8-J9W"/>
+                                        </connections>
+                                    </button>
                                     <customView horizontalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="P7w-qm-Tj1" userLabel="Done container">
                                         <rect key="frame" x="0.0" y="0.0" width="410" height="50"/>
                                         <subviews>
@@ -1618,8 +1628,10 @@ Gw
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -1644,6 +1656,7 @@ Gw
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="assistPathUpgradingCheckbox" destination="wtN-ul-9kg" id="7Gj-km-cft"/>
                         <outlet property="launchAtLoginCheckbox" destination="0ht-iC-Bc3" id="gDM-sN-S3r"/>
                         <outlet property="showInDockCheckbox" destination="5mk-S8-qPc" id="myl-zb-Mea"/>
                         <outlet property="showInStatusBarCheckbox" destination="BB1-ZH-rOd" id="uA4-Rv-NiC"/>

--- a/EduVPN-redesign/Services/ConnectionService.swift
+++ b/EduVPN-redesign/Services/ConnectionService.swift
@@ -254,7 +254,11 @@ private extension ConnectionService {
         }
         return Promise { resolver in
             do {
-                try tunnelManager.session.startTunnel()
+                let options: [String: Any] = [
+                    "assistPathUpgradingWithPathMonitor":
+                        UserDefaults.standard.assistPathUpgradingWithPathMonitor
+                ]
+                try tunnelManager.session.startTunnel(options: options)
             } catch {
                 throw error
             }

--- a/EduVPNTunnelExtension-macOS/PacketTunnelProvider.swift
+++ b/EduVPNTunnelExtension-macOS/PacketTunnelProvider.swift
@@ -6,4 +6,11 @@
 import TunnelKit
 
 class PacketTunnelProvider: OpenVPNTunnelProvider {
+    override func startTunnel(options: [String: NSObject]? = nil, completionHandler: @escaping (Error?) -> Void) {
+        let assistPathUpgradingWithPathMonitor = (options?["assistPathUpgradingWithPathMonitor"] as? NSNumber)?.boolValue ?? false
+        if assistPathUpgradingWithPathMonitor {
+            setPathMonitorUsageMode(.assistPathUpgrading)
+        }
+        super.startTunnel(options: options, completionHandler: completionHandler)
+    }
 }


### PR DESCRIPTION
This is intended to fix #311, but it's not clear yet whether it actually fixes it.

This uses NWPathMonitor to figure out when a hasBetterPath change should trigger a reconnection. Since I've not been able to reproduce the reconnection issue well, I've implemented what I think would be a fix, without really being able to verify that it works. So, this PR is made against a new "experimental" branch instead of master. Once merged to "experimental" after review, @efef can build with that and verify the fix.

This PR also exposes an option in the app's Preferences to turn the fix on/off.