### PR TITLE
macOS: MainVC: Fix crash when right-clicking on a 'filler' row

### DIFF
--- a/EduVPN-redesign/Controllers/MainViewController+macOS.swift
+++ b/EduVPN-redesign/Controllers/MainViewController+macOS.swift
@@ -44,6 +44,7 @@ extension MainViewController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
         let index = tableView.clickedRow
+        guard index >= 0 && index < numberOfRows() else { return }
         if canDeleteRow(at: index) {
             let serverNameItem = NSMenuItem(title: displayText(at: index), action: nil, keyEquivalent: "")
             serverNameItem.isEnabled = false


### PR DESCRIPTION
Avoid out-of-bounds array lookup when right-clicking on a 'filler' row, below the valid rows, in the main screen.

Fixes issue #346.