### PR TITLE
Cleanup UI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       uses: norio-nomura/action-swiftlint@3.0.1
 
   build-ios:
-    name: Build and test iOS target
+    name: Build iOS target
     runs-on: macOS-latest
 
     steps:
@@ -44,8 +44,8 @@ jobs:
       run: cp Config/iOS/Developer.xcconfig.eduvpn-template Config/iOS/Developer.xcconfig
     - name: Prepare config.json
       run: cp Config/iOS/config-eduvpn_new_discovery.json Config/iOS/config.json
-    - name: Run tests on iOS 14
-      run: xcodebuild test -scheme EduVPN-iOS -workspace EduVPN.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.3' -skip-testing EduVPN-UITests-iOS | xcpretty && exit ${PIPESTATUS[0]}
+    - name: Build for Generic iOS device
+      run: xcodebuild build -scheme EduVPN-iOS -workspace EduVPN.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.3' -skip-testing EduVPN-UITests-iOS | xcpretty && exit ${PIPESTATUS[0]}
 
   build-macos:
     name: Build macOS target

--- a/EduVPN-UITests-iOS/EduVPNUITestsiOS.swift
+++ b/EduVPN-UITests-iOS/EduVPNUITestsiOS.swift
@@ -8,18 +8,21 @@
 
 import XCTest
 
-struct Credentials {
+struct DemoInstituteAccessServerCredentials {
+    let username: String
+    let password: String
+}
+
+struct CustomServerCredentials {
     let host: String
     let username: String
     let password: String
 }
 
-// Fill these before running the tests
-//let demoCredentials = Credentials(host: <#T##String#>, username: <#T##String#>, password: <#T##String#>)
-//let customCredentials = Credentials(host: <#T##String#>, username: <#T##String#>, password: <#T##String#>)
-// These need to be here so the tests at least compile on GitHub Actions
-let demoCredentials = Credentials(host: "", username: "", password: "")
-let customCredentials = Credentials(host: "", username: "", password: "")
+struct TestServerCredentials {
+    let demoInstituteAccessServerCredentials: DemoInstituteAccessServerCredentials?
+    let customServerCredentials: CustomServerCredentials?
+}
 
 class EduVPNUITestsiOS: XCTestCase {
 
@@ -129,9 +132,13 @@ class EduVPNUITestsiOS: XCTestCase {
         thenIShouldSeeCell(app, label: "Demo")
     }
     
-    func testAddInstituteAccess() {
+    func testAddInstituteAccess() throws {
         // Scenario: Adding a provider for institute access
-        
+
+        guard let demoCredentials = testServerCredentialsiOS.demoInstituteAccessServerCredentials else {
+            throw XCTSkip("No credentials provided for Demo Institute Access server")
+        }
+
         // Given I launched a configured app
         let app = givenILaunchedAConfiguredApp()
         
@@ -154,7 +161,7 @@ class EduVPNUITestsiOS: XCTestCase {
         whenITapCell(app, label: "Demo")
         
         // When I authenticate with Demo
-        whenIAuthenticateWithDemo(app)
+        whenIAuthenticateWithDemo(app, credentials: demoCredentials)
     }
     
     func testAddSecureInternet() {
@@ -197,9 +204,13 @@ class EduVPNUITestsiOS: XCTestCase {
         thenIShouldSeeScreenWithTitle(app, title: "Add Server")
     }
     
-    func testAddCustomServer() {
+    func testAddCustomServer() throws {
         // Scenario: A custom server can be added and connected to
-        
+
+        guard let customCredentials = testServerCredentialsiOS.customServerCredentials else {
+            throw XCTSkip("No credentials provided for custom server")
+        }
+
         // Given I launched a freshly installed app
         let app = givenILaunchedAFreshlyInstalledApp()
         
@@ -346,9 +357,13 @@ class EduVPNUITestsiOS: XCTestCase {
         thenIShouldNotSeeCell(app, label: "Demo")
     }
     
-    func testConnectVPN() {
+    func testConnectVPN() throws {
         // Scenario: Should be able to setup connection
-        
+
+        guard let demoCredentials = testServerCredentialsiOS.demoInstituteAccessServerCredentials else {
+            throw XCTSkip("No credentials provided for Demo Institute Access server")
+        }
+
         // Given I launched a configured app
         let app = givenILaunchedAConfiguredApp()
         
@@ -367,7 +382,7 @@ class EduVPNUITestsiOS: XCTestCase {
         if needAuthentication {
        
             // When I authenticate with Demo
-            whenIAuthenticateWithDemo(app)
+            whenIAuthenticateWithDemo(app, credentials: demoCredentials)
             
         }
         
@@ -658,7 +673,10 @@ private extension EduVPNUITestsiOS {
         app.swipeUp() // Interaction with app needed for some reasone
     }
 
-    private func whenIAuthenticateWithDemo(_ app: XCUIApplication) {
+    private func whenIAuthenticateWithDemo(
+        _ app: XCUIApplication,
+        credentials: DemoInstituteAccessServerCredentials) {
+
         // When I tap "Continue" button in system alert
         whenITapButtonInSystemAlert(app, label: "Continue")
         
@@ -684,13 +702,13 @@ private extension EduVPNUITestsiOS {
         whenIStartTypingInTheTextfield(app, label: "e.g. user@gmail.com")
         
         // When I type "********"
-        whenIType(app, text: demoCredentials.username)
+        whenIType(app, text: credentials.username)
         
         // When I start typing in the secure "Password" textfield
         whenIStartTypingInTheSecureTextfield(app, label: "Password")
         
         // When I type "********"
-        whenIType(app, text: demoCredentials.password)
+        whenIType(app, text: credentials.password)
         
         // When I tap "Done" button
         whenITapButton(app, label: "Done")
@@ -707,7 +725,7 @@ private extension EduVPNUITestsiOS {
         if needApproval {
             
             // Then I should see webpage with host "host"
-            thenIShouldSeeWebpageWithHost(app, host: demoCredentials.host)
+            thenIShouldSeeWebpageWithHost(app, host: "demo.eduvpn.nl")
             
             // When I tap "Approve" button
             whenITapButton(app, label: "Approve")

--- a/EduVPN-UITests-iOS/TestServerCredentialsiOS.swift-template
+++ b/EduVPN-UITests-iOS/TestServerCredentialsiOS.swift-template
@@ -1,0 +1,17 @@
+//
+//  TestCredentialsiOS.swift
+//  EduVPN-UITests-iOS
+//
+
+let testServerCredentialsiOS = TestServerCredentials(
+    demoInstituteAccessServerCredentials:
+        // Provide demo server credentials
+        DemoInstituteAccessServerCredentials(username: "", password: ""),
+        // or skip tests involving the demo institute with "nil"
+        // nil,
+    customServerCredentials:
+        // Provide demo server credentials
+        CustomServerCredentials(host: "", username: "", password: "")
+        // or skip tests involving the demo institute with "nil"
+        // nil,
+)

--- a/EduVPN-UITests-iOS/TestServerCredentialsiOS.swift-template
+++ b/EduVPN-UITests-iOS/TestServerCredentialsiOS.swift-template
@@ -7,11 +7,11 @@ let testServerCredentialsiOS = TestServerCredentials(
     demoInstituteAccessServerCredentials:
         // Provide demo server credentials
         DemoInstituteAccessServerCredentials(username: "", password: ""),
-        // or skip tests involving the demo institute with "nil"
+        // or specify "nil" to skip tests involving the demo institute
         // nil,
     customServerCredentials:
-        // Provide demo server credentials
+        // Provide custom server credentials
         CustomServerCredentials(host: "", username: "", password: "")
-        // or skip tests involving the demo institute with "nil"
+        // or specify "nil" to skip tests involving a custom server
         // nil,
 )

--- a/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
+++ b/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
@@ -8,18 +8,21 @@
 
 import XCTest
 
-struct Credentials {
+struct DemoInstituteAccessServerCredentials {
+    let username: String
+    let password: String
+}
+
+struct CustomServerCredentials {
     let host: String
     let username: String
     let password: String
 }
 
-// Fill these before running the tests
-//let demoCredentials = Credentials(host: <#T##String#>, username: <#T##String#>, password: <#T##String#>)
-//let customCredentials = Credentials(host: <#T##String#>, username: <#T##String#>, password: <#T##String#>)
-// These need to be here so the tests at least compile on GitHub Actions
-let demoCredentials = Credentials(host: "", username: "", password: "")
-let customCredentials = Credentials(host: "", username: "", password: "")
+struct TestServerCredentials {
+    let demoInstituteAccessServerCredentials: DemoInstituteAccessServerCredentials?
+    let customServerCredentials: CustomServerCredentials?
+}
 
 class EduVPNUITestsmacOS: XCTestCase {
 
@@ -123,9 +126,13 @@ class EduVPNUITestsmacOS: XCTestCase {
         thenIShouldSeeCell(app, label: "Demo")
     }
     
-    func testAddInstituteAccess() {
+    func testAddInstituteAccess() throws {
         // Scenario: Adding a provider for institute access
-        
+
+        guard let demoCredentials = testServerCredentialsmacOS.demoInstituteAccessServerCredentials else {
+            throw XCTSkip("No credentials provided for Demo Institute Access server")
+        }
+
         // Given I launched a configured app
         let app = givenILaunchedAConfiguredApp()
         
@@ -148,7 +155,7 @@ class EduVPNUITestsmacOS: XCTestCase {
         whenIClickCell(app, label: "Demo")
         
         // When I authenticate with Demo
-        whenIAuthenticateWithDemo(app)
+        whenIAuthenticateWithDemo(app, credentials: demoCredentials)
     }
     
     func testAddSecureInternet() {
@@ -191,9 +198,13 @@ class EduVPNUITestsmacOS: XCTestCase {
         thenIShouldSeeCell(app, label: "SURFnet bv")
     }
     
-    func testAddCustomServer() {
+    func testAddCustomServer() throws {
         // Scenario: A custom server can be added and connected to
-        
+
+        guard let customCredentials = testServerCredentialsmacOS.customServerCredentials else {
+            throw XCTSkip("No credentials provided for custom server")
+        }
+
         // Given I launched a freshly installed app
         let app = givenILaunchedAFreshlyInstalledApp()
         
@@ -342,9 +353,13 @@ class EduVPNUITestsmacOS: XCTestCase {
         thenIShouldNotSeeCell(app, label: "Demo")
     }
     
-    func testConnectVPN() {
+    func testConnectVPN() throws {
         // Scenario: Should be able to setup connection
-        
+
+        guard let demoCredentials = testServerCredentialsmacOS.demoInstituteAccessServerCredentials else {
+            throw XCTSkip("No credentials provided for Demo Institute Access server")
+        }
+
         // Given I launched a configured app
         let app = givenILaunchedAConfiguredApp()
         
@@ -360,7 +375,7 @@ class EduVPNUITestsmacOS: XCTestCase {
         if needAuthentication {
        
             // When I authenticate with Demo
-            whenIAuthenticateWithDemo(app)
+            whenIAuthenticateWithDemo(app, credentials: demoCredentials)
             
         }
         
@@ -678,7 +693,10 @@ private extension EduVPNUITestsmacOS {
         app.activate() // Interaction with app needed for some reasone
     }
 
-    private func whenIAuthenticateWithDemo(_ app: XCUIApplication) {
+    private func whenIAuthenticateWithDemo(
+        _ app: XCUIApplication,
+        credentials: DemoInstituteAccessServerCredentials) {
+
         // When I wait 3 seconds
         whenIWait(time: 3)
         
@@ -704,13 +722,13 @@ private extension EduVPNUITestsmacOS {
             whenIStartTypingInTheTextfield(safari, label: "e.g. user@gmail.com")
             
             // When I type "********"
-            whenIType(safari, text: demoCredentials.username)
+            whenIType(safari, text: credentials.username)
             
             // When I start typing in the secure "Password" textfield
             whenIStartTypingInTheSecureTextfield(safari, label: "Password")
             
             // When I type "********"
-            whenIType(safari, text: demoCredentials.password)
+            whenIType(safari, text: credentials.password)
             
             // When I click "Login" link
             whenIClickLink(safari, label: "Login")
@@ -725,7 +743,7 @@ private extension EduVPNUITestsmacOS {
         if needApproval {
             
             // Then I should see webpage with host "host"
-            thenIShouldSeeWebpageWithHost(safari, host: demoCredentials.host)
+            thenIShouldSeeWebpageWithHost(safari, host: "demo.eduvpn.nl")
             
             // When I click "Approve" button
             whenIClickButton(safari, label: "Approve")

--- a/EduVPN-UITests-macOS/TestServerCredentialsmacOS.swift-template
+++ b/EduVPN-UITests-macOS/TestServerCredentialsmacOS.swift-template
@@ -1,0 +1,17 @@
+//
+//  TestServerCredentialsmacOS.swift
+//  EduVPN-UITests-macOS
+//
+
+let testServerCredentialsmacOS = TestServerCredentials(
+    demoInstituteAccessServerCredentials:
+        // Provide demo server credentials
+        DemoInstituteAccessServerCredentials(username: "", password: ""),
+        // or skip tests involving the demo institute with "nil"
+        // nil,
+    customServerCredentials:
+        // Provide demo server credentials
+        CustomServerCredentials(host: "", username: "", password: "")
+        // or skip tests involving the demo institute with "nil"
+        // nil,
+)

--- a/EduVPN-UITests-macOS/TestServerCredentialsmacOS.swift-template
+++ b/EduVPN-UITests-macOS/TestServerCredentialsmacOS.swift-template
@@ -7,11 +7,11 @@ let testServerCredentialsmacOS = TestServerCredentials(
     demoInstituteAccessServerCredentials:
         // Provide demo server credentials
         DemoInstituteAccessServerCredentials(username: "", password: ""),
-        // or skip tests involving the demo institute with "nil"
+        // or specify "nil" to skip tests involving the demo institute
         // nil,
     customServerCredentials:
-        // Provide demo server credentials
+        // Provide custom server credentials
         CustomServerCredentials(host: "", username: "", password: "")
-        // or skip tests involving the demo institute with "nil"
+        // or specify "nil" to skip tests involving a custom server
         // nil,
 )

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		6F116CB425345D5200C73797 /* CertificateExpiryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F57338624CD1570008912D4 /* CertificateExpiryHelper.swift */; };
 		6F116CB525345D8100C73797 /* ConnectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DB4B43247FBDF5009932B1 /* ConnectionViewController.swift */; };
 		6F12815225C3E6060078E734 /* TestServerCredentialsiOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F12815125C3E6050078E734 /* TestServerCredentialsiOS.swift */; };
+		6F12816F25C3F6900078E734 /* TestServerCredentialsmacOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F12816E25C3F6900078E734 /* TestServerCredentialsmacOS.swift */; };
 		6F13E3E024977B8500E21614 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C6A248064BC009932B1 /* Assets.xcassets */; };
 		6F13E3E124977BA800E21614 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C6B248064BC009932B1 /* Main.storyboard */; };
 		6F13E3E424977C1300E21614 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C1A24805F9B009932B1 /* config.json */; };
@@ -302,6 +303,7 @@
 		6F05E64124D0A6AA008292F6 /* ErrorHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandling.swift; sourceTree = "<group>"; };
 		6F116CAC2534585700C73797 /* MockConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectionService.swift; sourceTree = "<group>"; };
 		6F12815125C3E6050078E734 /* TestServerCredentialsiOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestServerCredentialsiOS.swift; sourceTree = "<group>"; };
+		6F12816E25C3F6900078E734 /* TestServerCredentialsmacOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestServerCredentialsmacOS.swift; sourceTree = "<group>"; };
 		6F1A1C0024EE8EDB0040D6A2 /* SupportContactTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportContactTextView.swift; sourceTree = "<group>"; };
 		6F305A58254AA6C50067E744 /* LogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewController.swift; sourceTree = "<group>"; };
 		6F36A71C24B454AA00BA8F5E /* CountryFlags.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = CountryFlags.xcassets; sourceTree = "<group>"; };
@@ -837,6 +839,7 @@
 			isa = PBXGroup;
 			children = (
 				C79B63C9258A08C200C054CC /* EduVPNUITestsmacOS.swift */,
+				6F12816E25C3F6900078E734 /* TestServerCredentialsmacOS.swift */,
 				C79B63CB258A08C200C054CC /* Info.plist */,
 			);
 			path = "EduVPN-UITests-macOS";
@@ -1738,6 +1741,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F12816F25C3F6900078E734 /* TestServerCredentialsmacOS.swift in Sources */,
 				C79B63CA258A08C200C054CC /* EduVPNUITestsmacOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -1255,19 +1255,16 @@
 					};
 					C79B63C6258A08C200C054CC = {
 						CreatedOnToolsVersion = 12.2;
-						DevelopmentTeam = CRU5YWAZ4Y;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 6F750C2C24975A4300AF2C04;
 					};
 					C7B439292580CE4D00FEB2B1 = {
 						CreatedOnToolsVersion = 12.2;
-						DevelopmentTeam = CRU5YWAZ4Y;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 6F750CBD24975B9B00AF2C04;
 					};
 					C7B439492580D0F000FEB2B1 = {
 						CreatedOnToolsVersion = 12.2;
-						DevelopmentTeam = CRU5YWAZ4Y;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 6F750CBD24975B9B00AF2C04;
 					};

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		6F116CB325345D4E00C73797 /* ConnectionInfoHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE1D11A24CD952C002D3D0C /* ConnectionInfoHelper.swift */; };
 		6F116CB425345D5200C73797 /* CertificateExpiryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F57338624CD1570008912D4 /* CertificateExpiryHelper.swift */; };
 		6F116CB525345D8100C73797 /* ConnectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DB4B43247FBDF5009932B1 /* ConnectionViewController.swift */; };
+		6F12815225C3E6060078E734 /* TestServerCredentialsiOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F12815125C3E6050078E734 /* TestServerCredentialsiOS.swift */; };
 		6F13E3E024977B8500E21614 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C6A248064BC009932B1 /* Assets.xcassets */; };
 		6F13E3E124977BA800E21614 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C6B248064BC009932B1 /* Main.storyboard */; };
 		6F13E3E424977C1300E21614 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C1A24805F9B009932B1 /* config.json */; };
@@ -300,6 +301,7 @@
 		6B9A8DF8C8CCA27F6D91B0B6 /* Pods-EduVPNTunnelExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EduVPNTunnelExtension.release.xcconfig"; path = "Target Support Files/Pods-EduVPNTunnelExtension/Pods-EduVPNTunnelExtension.release.xcconfig"; sourceTree = "<group>"; };
 		6F05E64124D0A6AA008292F6 /* ErrorHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandling.swift; sourceTree = "<group>"; };
 		6F116CAC2534585700C73797 /* MockConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectionService.swift; sourceTree = "<group>"; };
+		6F12815125C3E6050078E734 /* TestServerCredentialsiOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestServerCredentialsiOS.swift; sourceTree = "<group>"; };
 		6F1A1C0024EE8EDB0040D6A2 /* SupportContactTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportContactTextView.swift; sourceTree = "<group>"; };
 		6F305A58254AA6C50067E744 /* LogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewController.swift; sourceTree = "<group>"; };
 		6F36A71C24B454AA00BA8F5E /* CountryFlags.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = CountryFlags.xcassets; sourceTree = "<group>"; };
@@ -853,6 +855,7 @@
 			isa = PBXGroup;
 			children = (
 				C7B4394C2580D0F000FEB2B1 /* EduVPNUITestsiOS.swift */,
+				6F12815125C3E6050078E734 /* TestServerCredentialsiOS.swift */,
 				C7B4394E2580D0F000FEB2B1 /* Info.plist */,
 			);
 			path = "EduVPN-UITests-iOS";
@@ -1752,6 +1755,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7B4394D2580D0F000FEB2B1 /* EduVPNUITestsiOS.swift in Sources */,
+				6F12815225C3E6060078E734 /* TestServerCredentialsiOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -2501,7 +2501,6 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "EduVPN-UITests-macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).EduVPN-UITests-macOS";
@@ -2526,7 +2525,6 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "EduVPN-UITests-macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).EduVPN-UITests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -99,3 +99,49 @@ $ vim Config/iOS/Developer.xcconfig # Edit as reqd.
 
 Then, open `EduVPN.xcworkspace` in Xcode and build the 'EduVPN-iOS' target.
 
+## Testing
+
+The app can be tested using UI tests written using XCUITest.
+
+The tests can modify the app data, so to avoid losing your added
+servers, it's recommended that you use a separate app bundle identifier
+for running the UI tests. The app bundle identifier is configurable in
+Developer.xcconfig or Developer-macOS.xcconfig as specified above.
+
+### Testing the eduVPN iOS app
+
+The iOS UI tests are intended to be run on a physical device (not on the
+iOS Simulator).
+
+Before running the tests, specify the server credentials:
+
+```
+$ cp EduVPN-UITests-iOS/TestServerCredentialsiOS.swift-template EduVPN-UITests-iOS/TestServerCredentialsiOS.swift
+$ vim EduVPN-UITests-iOS/TestServerCredentialsiOS.swift # Enter credentials
+```
+
+Then:
+ 1. Open `EduVPN.xcworkspace` in Xcode
+ 2. In the scheme selector breadcrumb panel, select the 'EduVPN-iOS'
+    scheme and your connected iDevice
+ 3. Click on Product > Test
+
+Do not use the iDevice when the test is running.
+
+### Testing the eduVPN macOS app
+
+Before running the tests, specify the server credentials:
+
+```
+$ cp EduVPN-UITests-macOS/TestServerCredentialsmacOS.swift-template EduVPN-UITests-iOS/TestServerCredentialsmacOS.swift
+$ vim EduVPN-UITests-macOS/TestServerCredentialsmacOS.swift # Enter credentials
+```
+
+Then:
+ 1. Open a new window in Safari.app
+ 2. Open `EduVPN.xcworkspace` in Xcode
+ 3. In the scheme selector breadcrumb panel, select the 'EduVPN-iOS'
+    scheme and the macOS machine
+ 4. Click on Product > Test
+
+Do not use the macOS machine when the test is running.


### PR DESCRIPTION
This PR does the following:
 - Move credentials to a separate file, so that they can be left out of Git versioning
 - Allow credential to be nil, which will cause the test using that to be skipped
 - Update README
 - Bring down deployment target for macOS tests
