### PR TITLE
Fix UI tests

### DIFF
--- a/EduVPN-UITests-iOS/EduVPNUITestsiOS.swift
+++ b/EduVPN-UITests-iOS/EduVPNUITestsiOS.swift
@@ -271,9 +271,6 @@ class EduVPNUITestsiOS: XCTestCase {
             whenIWait(time: 10)
         }
         
-        // Then I should see "Other servers" label
-        thenIShouldSeeLabel(app, label: "Other servers")
-        
         // Then I should see "https:// + host" cell
         thenIShouldSeeCell(app, label: "https://" + customCredentials.host + "/")
         

--- a/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
+++ b/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
@@ -270,9 +270,6 @@ class EduVPNUITestsmacOS: XCTestCase {
             whenIWait(time: 10)
         }
         
-        // Then I should see "Other servers" label
-        thenIShouldSeeLabel(app, label: "Other servers")
-        
         // Then I should see "https:// + host" cell
         thenIShouldSeeCell(app, label: "https://" + customCredentials.host + "/")
         

--- a/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
+++ b/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
@@ -156,6 +156,9 @@ class EduVPNUITestsmacOS: XCTestCase {
         
         // When I authenticate with Demo
         whenIAuthenticateWithDemo(app, credentials: demoCredentials)
+
+        // Then I should see "Demo" cell
+        thenIShouldSeeCell(app, label: "Demo")
     }
     
     func testAddSecureInternet() {
@@ -713,10 +716,16 @@ private extension EduVPNUITestsmacOS {
         
         // Then I might see webpage with host "login.eduid.nl"
         let (needLogin, _) = thenIMightSeeWebpageWithHost(safari, host: "login.eduid.nl")
-        
+
         if needLogin {
+            // When I click "Login!" link (if it exists)
+            whenIClickLink(safari, label: "Login!")
+
+            // When I wait 3 seconds
+            whenIWait(time: 3)
+
             // When I click "Type a password." link
-            whenIClickLink(safari, label: "Type a password.")
+            whenIClickLink(safari, label: "type a password.")
             
             // When I start typing in the "e.g. user@gmail.com" textfield
             whenIStartTypingInTheTextfield(safari, label: "e.g. user@gmail.com")
@@ -747,6 +756,9 @@ private extension EduVPNUITestsmacOS {
             
             // When I click "Approve" button
             whenIClickButton(safari, label: "Approve")
+
+            // When I wait 10 seconds
+            whenIWait(time: 10)
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ $ vim EduVPN-UITests-iOS/TestServerCredentialsiOS.swift # Enter credentials
 
 Then:
  1. Open `EduVPN.xcworkspace` in Xcode
- 2. In the scheme selector breadcrumb panel, select the 'EduVPN-iOS'
+ 2. Ensure the test targets (EduVPN-Tests-iOS, EduVPN-UITests-iOS) have
+    correct 'Team' set under 'Signing & Capabilities'
+ 3. In the scheme selector breadcrumb panel, select the 'EduVPN-iOS'
     scheme and your connected iDevice
- 3. Click on Product > Test
+ 4. Click on Product > Test
 
 Do not use the iDevice when the test is running.
 
@@ -138,10 +140,12 @@ $ vim EduVPN-UITests-macOS/TestServerCredentialsmacOS.swift # Enter credentials
 ```
 
 Then:
- 1. Open a new window in Safari.app
+ 1. Open Safari.app, open a new private window, close all other windows
  2. Open `EduVPN.xcworkspace` in Xcode
- 3. In the scheme selector breadcrumb panel, select the 'EduVPN-iOS'
+ 3. Ensure the test targets (EduVPN-Tests-macOS, EduVPN-UITests-macOS) have
+    correct 'Team' set under 'Signing & Capabilities'
+ 4. In the scheme selector breadcrumb panel, select the 'EduVPN-iOS'
     scheme and the macOS machine
- 4. Click on Product > Test
+ 5. Click on Product > Test
 
 Do not use the macOS machine when the test is running.


### PR DESCRIPTION
- Fix the eduID login mechanism for the 'Demo' server
- The 'Other servers' section header is now hidden when that's the only section, so make the tests not check for that section header
