### PR TITLE
Notify before session expiry

### DIFF
--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		6F7B63F02500FD7300FB154A /* StatusItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7B63EF2500FD7300FB154A /* StatusItemController.swift */; };
 		6F7B63F225022AAE00FB154A /* LaunchAtLoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7B63F125022AAE00FB154A /* LaunchAtLoginHelper.swift */; };
 		6F7B643E2502A18D00FB154A /* ConnectionInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7B643D2502A18C00FB154A /* ConnectionInfoHeaderView.swift */; };
+		6F85D3C025F7FD3B00E8B513 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F85D3BF25F7FD3B00E8B513 /* NotificationService.swift */; };
+		6F85D3C125F7FD3B00E8B513 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F85D3BF25F7FD3B00E8B513 /* NotificationService.swift */; };
 		6F8835EC24FCD481008F15FF /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8835EB24FCD481008F15FF /* MainWindowController.swift */; };
 		6F885F7025C14FA500CABF4E /* OpenVPNConfigCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F885F6F25C14FA500CABF4E /* OpenVPNConfigCredentials.swift */; };
 		6F885F7125C14FA500CABF4E /* OpenVPNConfigCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F885F6F25C14FA500CABF4E /* OpenVPNConfigCredentials.swift */; };
@@ -345,6 +347,7 @@
 		6F7B63EF2500FD7300FB154A /* StatusItemController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusItemController.swift; sourceTree = "<group>"; };
 		6F7B63F125022AAE00FB154A /* LaunchAtLoginHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginHelper.swift; sourceTree = "<group>"; };
 		6F7B643D2502A18C00FB154A /* ConnectionInfoHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionInfoHeaderView.swift; sourceTree = "<group>"; };
+		6F85D3BF25F7FD3B00E8B513 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		6F8835EB24FCD481008F15FF /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
 		6F885F6F25C14FA500CABF4E /* OpenVPNConfigCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenVPNConfigCredentials.swift; sourceTree = "<group>"; };
 		6F885F7B25C1740D00CABF4E /* CredentialsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsViewController.swift; sourceTree = "<group>"; };
@@ -931,6 +934,7 @@
 				6FC27AC724B9550C006FA648 /* ServerAPIService.swift */,
 				6FBFEF0B24C0680800A9D1D4 /* ConnectionService.swift */,
 				6F116CAC2534585700C73797 /* MockConnectionService.swift */,
+				6F85D3BF25F7FD3B00E8B513 /* NotificationService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1862,6 +1866,7 @@
 				C7D3BB3F258368F900A37244 /* Testing.swift in Sources */,
 				6FD5CDA224C467CB00842A74 /* ServerDisplayInfo.swift in Sources */,
 				C7DB4BA0247FC23D009932B1 /* PreferencesViewController.swift in Sources */,
+				6F85D3C025F7FD3B00E8B513 /* NotificationService.swift in Sources */,
 				6FC27AC824B9550D006FA648 /* ServerAPIService.swift in Sources */,
 				6FD5CDA424C678CF00842A74 /* ConnectionViewModel+Localization.swift in Sources */,
 				6F7B643E2502A18D00FB154A /* ConnectionInfoHeaderView.swift in Sources */,
@@ -1899,6 +1904,7 @@
 				6F5E6C3E2522E93D000225C0 /* ServerResponse.swift in Sources */,
 				6F5E6C322522E72F000225C0 /* SectionHeaderCell.swift in Sources */,
 				C7DB4C34248060F5009932B1 /* Config.swift in Sources */,
+				6F85D3C125F7FD3B00E8B513 /* NotificationService.swift in Sources */,
 				6F5E6C352522E8A0000225C0 /* Log.swift in Sources */,
 				6F5E6C432522E9BF000225C0 /* ServerDiscoveryService.swift in Sources */,
 				C7DB4C36248060F5009932B1 /* FileHelper.swift in Sources */,

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -160,6 +160,7 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
             self.viewModel = ConnectionViewModel(
                 server: server,
                 connectionService: parameters.environment.connectionService,
+                notificationService: parameters.environment.notificationService,
                 serverDisplayInfo: parameters.serverDisplayInfo,
                 serverAPIService: parameters.environment.serverAPIService,
                 authURLTemplate: parameters.authURLTemplate,

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -267,7 +267,7 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
         }
     }
 
-    @IBAction func renewSessionClicked(_ sender: Any) {
+    func renewSession() {
         firstly {
             viewModel.disableVPN()
         }.map {
@@ -278,6 +278,10 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
                    error.localizedDescription)
             self.showAlert(for: error)
         }
+    }
+
+    @IBAction func renewSessionClicked(_ sender: Any) {
+        renewSession()
     }
 
     #if os(macOS)

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -280,6 +280,10 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
         }
     }
 
+    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool> {
+        viewModel.scheduleSessionExpiryNotificationOnActiveVPN()
+    }
+
     @IBAction func renewSessionClicked(_ sender: Any) {
         renewSession()
     }

--- a/EduVPN/Controllers/Mac/PreferencesViewController.swift
+++ b/EduVPN/Controllers/Mac/PreferencesViewController.swift
@@ -29,6 +29,7 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
     private var parameters: Parameters!
 
     @IBOutlet weak var useTCPOnlyCheckbox: NSButton!
+    @IBOutlet weak var sessionExpiryNotificationCheckbox: NSButton!
     @IBOutlet weak var showInStatusBarCheckbox: NSButton!
     @IBOutlet weak var showInDockCheckbox: NSButton!
     @IBOutlet weak var launchAtLoginCheckbox: NSButton!
@@ -43,11 +44,13 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
     override func viewDidLoad() {
         let userDefaults = UserDefaults.standard
         let isForceTCPEnabled = userDefaults.forceTCP
+        let shouldNotifyBeforeSessionExpiry = userDefaults.shouldNotifyBeforeSessionExpiry
         let isShowInStatusBarEnabled = userDefaults.showInStatusBar
         let isShowInDockEnabled = userDefaults.showInDock
         let isLaunchAtLoginEnabled = userDefaults.launchAtLogin
 
         useTCPOnlyCheckbox.state = isForceTCPEnabled ? .on : .off
+        sessionExpiryNotificationCheckbox.state = shouldNotifyBeforeSessionExpiry ? .on : .off
         showInStatusBarCheckbox.state = isShowInStatusBarEnabled ? .on : .off
         showInDockCheckbox.state = isShowInDockEnabled ? .on : .off
         launchAtLoginCheckbox.state = isLaunchAtLoginEnabled ? .on : .off
@@ -65,6 +68,22 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
     @IBAction func useTCPOnlyCheckboxClicked(_ sender: Any) {
         let isUseTCPOnlyChecked = (useTCPOnlyCheckbox.state == .on)
         UserDefaults.standard.forceTCP = isUseTCPOnlyChecked
+    }
+
+    @IBAction func sessionExpiryNotificationCheckboxClicked(_ sender: Any) {
+        let isSessionExpiryNotificationChecked = (sessionExpiryNotificationCheckbox.state == .on)
+        let notificationService = parameters.environment.notificationService
+        if isSessionExpiryNotificationChecked {
+            firstly {
+                notificationService.enableCertificateExpiryNotification(from: self)
+            }.done { isEnabled in
+                if !isEnabled {
+                    self.sessionExpiryNotificationCheckbox.state = .off
+                }
+            }
+        } else {
+            notificationService.disableCertificateExpiryNotification()
+        }
     }
 
     @IBAction func viewLogClicked(_ sender: Any) {

--- a/EduVPN/Controllers/Mac/PreferencesViewController.swift
+++ b/EduVPN/Controllers/Mac/PreferencesViewController.swift
@@ -6,10 +6,6 @@
 import Foundation
 import PromiseKit
 
-protocol PreferencesViewControllerDelegate: class {
-    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool>
-}
-
 enum PreferencesViewControllerError: Error {
     case noLogAvailable
     case cannotShowLog
@@ -28,11 +24,10 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
 
     struct Parameters {
         let environment: Environment
+        let mainVC: MainViewController
     }
 
     private var parameters: Parameters!
-
-    weak var delegate: PreferencesViewControllerDelegate?
 
     @IBOutlet weak var useTCPOnlyCheckbox: NSButton!
     @IBOutlet weak var sessionExpiryNotificationCheckbox: NSButton!
@@ -79,12 +74,13 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
     @IBAction func sessionExpiryNotificationCheckboxClicked(_ sender: Any) {
         let isSessionExpiryNotificationChecked = (sessionExpiryNotificationCheckbox.state == .on)
         let notificationService = parameters.environment.notificationService
+        let mainVC = parameters.mainVC
         if isSessionExpiryNotificationChecked {
             firstly {
                 notificationService.enableSessionExpiryNotification(from: self)
             }.done { isEnabled in
                 if isEnabled {
-                    self.delegate?.scheduleSessionExpiryNotificationOnActiveVPN()
+                    mainVC.scheduleSessionExpiryNotificationOnActiveVPN()
                         .done { _ in }
                 } else {
                     self.sessionExpiryNotificationCheckbox.state = .off

--- a/EduVPN/Controllers/Mac/PreferencesViewController.swift
+++ b/EduVPN/Controllers/Mac/PreferencesViewController.swift
@@ -75,14 +75,14 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
         let notificationService = parameters.environment.notificationService
         if isSessionExpiryNotificationChecked {
             firstly {
-                notificationService.enableCertificateExpiryNotification(from: self)
+                notificationService.enableSessionExpiryNotification(from: self)
             }.done { isEnabled in
                 if !isEnabled {
                     self.sessionExpiryNotificationCheckbox.state = .off
                 }
             }
         } else {
-            notificationService.disableCertificateExpiryNotification()
+            notificationService.disableSessionExpiryNotification()
         }
     }
 

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -264,11 +264,6 @@ extension MainViewController: NotificationServiceDelegate {
     }
 }
 
-#if os(macOS)
-extension MainViewController: PreferencesViewControllerDelegate {
-}
-#endif
-
 extension MainViewController {
     func numberOfRows() -> Int {
         return viewModel?.numberOfRows() ?? 0

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -112,6 +112,13 @@ class MainViewController: ViewController {
             }
         }
     }
+
+    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool> {
+        guard let currentConnectionVC = currentConnectionVC else {
+            return Guarantee<Bool>.value(false)
+        }
+        return currentConnectionVC.scheduleSessionExpiryNotificationOnActiveVPN()
+    }
 }
 
 extension MainViewController: NavigationControllerAddButtonDelegate {
@@ -257,14 +264,10 @@ extension MainViewController: NotificationServiceDelegate {
     }
 }
 
+#if os(macOS)
 extension MainViewController: PreferencesViewControllerDelegate {
-    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool> {
-        guard let currentConnectionVC = currentConnectionVC else {
-            return Guarantee<Bool>.value(false)
-        }
-        return currentConnectionVC.scheduleSessionExpiryNotificationOnActiveVPN()
-    }
 }
+#endif
 
 extension MainViewController {
     func numberOfRows() -> Int {

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import os.log
+import PromiseKit
 
 protocol MainViewControllerDelegate: class {
     func mainViewControllerAddedServersListChanged(
@@ -253,6 +254,15 @@ extension MainViewController: NotificationServiceDelegate {
         } else {
             shouldRenewSessionWhenConnectionServiceInitialized = true
         }
+    }
+}
+
+extension MainViewController: PreferencesViewControllerDelegate {
+    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool> {
+        guard let currentConnectionVC = currentConnectionVC else {
+            return Guarantee<Bool>.value(false)
+        }
+        return currentConnectionVC.scheduleSessionExpiryNotificationOnActiveVPN()
     }
 }
 

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -241,7 +241,7 @@ extension MainViewController: ConnectionServiceInitializationDelegate {
 
         case .vpnDisabled:
             environment.persistenceService.removeLastConnectionAttempt()
-            environment.notificationService.descheduleSessionExpiryNotifications()
+            environment.notificationService.descheduleSessionExpiryNotification()
         }
     }
 }

--- a/EduVPN/Controllers/iOS/SettingsViewController.swift
+++ b/EduVPN/Controllers/iOS/SettingsViewController.swift
@@ -7,10 +7,6 @@ import UIKit
 import SafariServices
 import PromiseKit
 
-protocol PreferencesViewControllerDelegate: class {
-    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool>
-}
-
 enum SettingsViewControllerError: Error {
     case noLogAvailable
     case cannotShowLog
@@ -34,9 +30,8 @@ class SettingsViewController: UITableViewController, ParametrizedViewController 
 
     private var parameters: Parameters!
 
-    weak var delegate: PreferencesViewControllerDelegate?
-
     @IBOutlet weak var useTCPOnlySwitch: UISwitch!
+    @IBOutlet weak var sessionExpiryNotificationSwitch: UISwitch!
     @IBOutlet weak var appNameLabel: UILabel!
     @IBOutlet weak var appVersionLabel: UILabel!
 
@@ -53,8 +48,10 @@ class SettingsViewController: UITableViewController, ParametrizedViewController 
 
         let userDefaults = UserDefaults.standard
         let isForceTCPEnabled = userDefaults.forceTCP
+        let shouldNotifyBeforeSessionExpiry = userDefaults.shouldNotifyBeforeSessionExpiry
 
         useTCPOnlySwitch.isOn = isForceTCPEnabled
+        sessionExpiryNotificationSwitch.isOn = shouldNotifyBeforeSessionExpiry
 
         appNameLabel.text = Config.shared.appName
         appVersionLabel.text = appVersionString()
@@ -62,6 +59,27 @@ class SettingsViewController: UITableViewController, ParametrizedViewController 
 
     @IBAction func useTCPOnlySwitchToggled(_ sender: Any) {
         UserDefaults.standard.forceTCP = useTCPOnlySwitch.isOn
+    }
+
+    @IBAction func sessionExpiryNotificationSwitchToggled(_ sender: Any) {
+        let isSessionExpiryNotificationChecked = sessionExpiryNotificationSwitch.isOn
+        let notificationService = parameters.environment.notificationService
+        let mainVC = parameters.mainVC
+        if isSessionExpiryNotificationChecked {
+            firstly {
+                notificationService.enableSessionExpiryNotification(from: self)
+            }.done { isEnabled in
+                if isEnabled {
+                    mainVC.scheduleSessionExpiryNotificationOnActiveVPN()
+                        .done { _ in }
+                } else {
+                    self.sessionExpiryNotificationSwitch.isOn = false
+                }
+            }
+        } else {
+            notificationService.disableSessionExpiryNotification()
+            notificationService.descheduleSessionExpiryNotification()
+        }
     }
 
     @IBAction func importOpenVPNConfigTapped(_ sender: Any) {

--- a/EduVPN/Controllers/iOS/SettingsViewController.swift
+++ b/EduVPN/Controllers/iOS/SettingsViewController.swift
@@ -5,6 +5,11 @@
 
 import UIKit
 import SafariServices
+import PromiseKit
+
+protocol PreferencesViewControllerDelegate: class {
+    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool>
+}
 
 enum SettingsViewControllerError: Error {
     case noLogAvailable
@@ -28,6 +33,8 @@ class SettingsViewController: UITableViewController, ParametrizedViewController 
     }
 
     private var parameters: Parameters!
+
+    weak var delegate: PreferencesViewControllerDelegate?
 
     @IBOutlet weak var useTCPOnlySwitch: UISwitch!
     @IBOutlet weak var appNameLabel: UILabel!

--- a/EduVPN/Helpers/CertificateExpiryHelper.swift
+++ b/EduVPN/Helpers/CertificateExpiryHelper.swift
@@ -12,8 +12,9 @@ class CertificateExpiryHelper {
         case expired
     }
 
-    private let validFrom: Date
-    private let expiresAt: Date
+    let validFrom: Date
+    let expiresAt: Date
+
     private let handler: (CertificateStatus) -> Void
 
     fileprivate var refreshTimes: [(refreshAt: Date, state: CertificateStatus)]

--- a/EduVPN/Helpers/UserDefaults+Preferences.swift
+++ b/EduVPN/Helpers/UserDefaults+Preferences.swift
@@ -8,6 +8,9 @@ import Foundation
 extension UserDefaults {
 
     private static let forceTCPDefaultsKey = "force_tcp"
+    private static let shouldNotifyBeforeSessionExpiryKey = "shouldNotifyBeforeSessionExpiry"
+    // swiftlint:disable:next identifier_name
+    private static let hasAskedUserOnNotifyBeforeSessionExpiryKey = "hasAskedUserOnNotifyBeforeSessionExpiry"
     #if os(macOS)
     private static let showInStatusBarKey = "showInStatusBar"
     private static let showInDockKey = "showInDock"
@@ -20,6 +23,24 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Self.forceTCPDefaultsKey)
+        }
+    }
+
+    var shouldNotifyBeforeSessionExpiry: Bool {
+        get {
+            return bool(forKey: Self.shouldNotifyBeforeSessionExpiryKey)
+        }
+        set {
+            set(newValue, forKey: Self.shouldNotifyBeforeSessionExpiryKey)
+        }
+    }
+
+    var hasAskedUserOnNotifyBeforeSessionExpiry: Bool {
+        get {
+            return bool(forKey: Self.hasAskedUserOnNotifyBeforeSessionExpiryKey)
+        }
+        set {
+            set(newValue, forKey: Self.hasAskedUserOnNotifyBeforeSessionExpiryKey)
         }
     }
 

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -536,13 +536,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="1933" height="8"/>
+                                <rect key="frame" x="20" y="20" width="2005" height="8"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="1933" height="8"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2005" height="8"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="1933" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2005" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -771,11 +771,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="406" width="90" height="400"/>
+                                        <rect key="frame" x="195" y="366" width="90" height="440"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="361" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="321" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -783,7 +783,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="309" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="269" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -797,16 +797,16 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="265" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="225" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="0.0" y="0.0" width="479" height="253"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="479" height="213"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="479" height="253"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="479" height="213"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">
-                                                    <rect key="frame" x="0.0" y="0.0" width="479" height="253"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="479" height="213"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="20"/>
                                                     <color key="backgroundColor" red="0.92549019607843142" green="0.92549019607843142" blue="0.92549019607843142" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1486,10 +1486,10 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yI9-CM-5gZ">
-                                <rect key="frame" x="20" y="20" width="410" height="410"/>
+                                <rect key="frame" x="20" y="20" width="410" height="512"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rjv-VU-vqt">
-                                        <rect key="frame" x="-2" y="377" width="414" height="33"/>
+                                        <rect key="frame" x="-2" y="479" width="414" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Preferences" id="8ia-lI-dqX">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1497,10 +1497,10 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="GMI-07-EVu">
-                                        <rect key="frame" x="0.0" y="358" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="460" width="410" height="5"/>
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bZ6-la-8zq">
-                                        <rect key="frame" x="-2" y="327" width="175" height="19"/>
+                                        <rect key="frame" x="-2" y="429" width="175" height="19"/>
                                         <buttonCell key="cell" type="check" title="Connect using TCP only" bezelStyle="regularSquare" imagePosition="left" inset="2" id="t0F-zx-2Sp">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1509,15 +1509,36 @@ Gw
                                             <action selector="useTCPOnlyCheckboxClicked:" target="46m-sg-SJs" id="mh7-LA-MER"/>
                                         </connections>
                                     </button>
-                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="F1W-bg-sSw">
-                                        <rect key="frame" x="16" y="275" width="396" height="38"/>
-                                        <textFieldCell key="cell" selectable="YES" title="Changes to this option will take effect from the next connection onwards" id="rqy-tm-oLB">
+                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="F1W-bg-sSw" userLabel="UseTCP info">
+                                        <rect key="frame" x="16" y="377" width="396" height="38"/>
+                                        <textFieldCell key="cell" selectable="YES" title="Changes to this option will take effect from the next connection onwards." id="rqy-tm-oLB">
                                             <font key="font" size="14" name="OpenSans-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Xq3-ya-gMs">
+                                        <rect key="frame" x="0.0" y="358" width="410" height="5"/>
+                                    </box>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HMt-Bk-EIQ">
+                                        <rect key="frame" x="-2" y="327" width="296" height="19"/>
+                                        <buttonCell key="cell" type="check" title="Notify when the session is about to expire" bezelStyle="regularSquare" imagePosition="left" inset="2" id="qUc-Jr-rVi">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" size="14" name="OpenSans-Regular"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="sessionExpiryNotificationCheckboxClicked:" target="46m-sg-SJs" id="qpC-dJ-F7M"/>
+                                        </connections>
+                                    </button>
+                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Oi4-NS-aHo" userLabel="Notification info">
+                                        <rect key="frame" x="16" y="275" width="396" height="38"/>
+                                        <textFieldCell key="cell" selectable="YES" title="If enabled, a notification is triggered 30 mins before session expiry." id="Xc0-6z-lDX">
+                                            <font key="font" size="14" name="OpenSans-Regular"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="2Ow-MZ-6TT">
                                         <rect key="frame" x="0.0" y="256" width="410" height="5"/>
                                     </box>
                                     <customView horizontalHuggingPriority="100" verticalHuggingPriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="HhY-AU-L8g" userLabel="Connect log container">
@@ -1613,8 +1634,12 @@ Gw
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="F1W-bg-sSw" firstAttribute="leading" secondItem="yI9-CM-5gZ" secondAttribute="leading" constant="18" id="EWm-36-Hvs"/>
+                                    <constraint firstItem="Oi4-NS-aHo" firstAttribute="leading" secondItem="yI9-CM-5gZ" secondAttribute="leading" constant="18" id="GEG-xt-kLX"/>
                                 </constraints>
                                 <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
@@ -1643,6 +1668,9 @@ Gw
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
                                 </customSpacing>
                             </stackView>
                         </subviews>
@@ -1655,6 +1683,7 @@ Gw
                     </view>
                     <connections>
                         <outlet property="launchAtLoginCheckbox" destination="0ht-iC-Bc3" id="gDM-sN-S3r"/>
+                        <outlet property="sessionExpiryNotificationCheckbox" destination="HMt-Bk-EIQ" id="J71-G8-g6r"/>
                         <outlet property="showInDockCheckbox" destination="5mk-S8-qPc" id="myl-zb-Mea"/>
                         <outlet property="showInStatusBarCheckbox" destination="BB1-ZH-rOd" id="uA4-Rv-NiC"/>
                         <outlet property="useTCPOnlyCheckbox" destination="bZ6-la-8zq" id="39H-tz-8xE"/>

--- a/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
@@ -216,26 +216,26 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Find your institute" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4I8-Zx-Jlu">
-                                        <rect key="frame" x="0.0" y="181" width="414" height="33"/>
+                                        <rect key="frame" x="0.0" y="181" width="414" height="28"/>
                                         <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="24"/>
                                         <color key="textColor" name="BoldUITextColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <searchBar contentMode="redraw" verticalHuggingPriority="500" searchBarStyle="minimal" placeholder="Search for your institute..." translatesAutoresizingMaskIntoConstraints="NO" id="jE7-4D-h8q">
-                                        <rect key="frame" x="0.0" y="226" width="414" height="56"/>
+                                        <rect key="frame" x="0.0" y="221" width="414" height="56"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                         <connections>
                                             <outlet property="delegate" destination="GFf-Kn-0Ob" id="EC3-oh-xNy"/>
                                         </connections>
                                     </searchBar>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="eXL-Ez-0M0" userLabel="Spinner">
-                                        <rect key="frame" x="0.0" y="294" width="414" height="20"/>
+                                        <rect key="frame" x="0.0" y="289" width="414" height="20"/>
                                     </activityIndicatorView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="grl-2e-g9Z" userLabel="Table Container View">
-                                        <rect key="frame" x="0.0" y="326" width="414" height="492"/>
+                                        <rect key="frame" x="0.0" y="321" width="414" height="497"/>
                                         <subviews>
                                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XC9-sv-Z66">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="492"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="497"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <prototypes>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchRowCell" textLabel="G3K-Yo-Vb7" style="IBUITableViewCellStyleDefault" id="jg4-Se-j3E" userLabel="Search Row" customClass="RowCell" customModule="eduVPN" customModuleProvider="target">
@@ -256,21 +256,21 @@
                                                         </tableViewCellContentView>
                                                     </tableViewCell>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MainSectionHeaderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchSectionHeaderCell" id="51I-6k-mhR" userLabel="Search Section Header" customClass="SectionHeaderCell" customModule="eduVPN" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="71.5" width="414" height="78"/>
+                                                        <rect key="frame" x="0.0" y="71.5" width="414" height="74"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="51I-6k-mhR" id="cia-KD-gGj">
-                                                            <rect key="frame" x="0.0" y="0.0" width="414" height="78"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="414" height="74"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IcM-3F-aG1">
-                                                                    <rect key="frame" x="20" y="32" width="30" height="30"/>
+                                                                    <rect key="frame" x="20" y="30" width="30" height="30"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="30" id="OBV-OS-LVp"/>
                                                                         <constraint firstAttribute="height" constant="30" id="UX2-z3-Yrc"/>
                                                                     </constraints>
                                                                 </imageView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tWc-Vs-nt9">
-                                                                    <rect key="frame" x="60" y="35" width="334" height="28"/>
+                                                                    <rect key="frame" x="60" y="35" width="334" height="24"/>
                                                                     <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="20"/>
                                                                     <color key="textColor" name="BoldUITextColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -291,7 +291,7 @@
                                                         </connections>
                                                     </tableViewCell>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchNoResultsCell" textLabel="p7f-Cm-ntA" style="IBUITableViewCellStyleDefault" id="UGc-9h-dOK" userLabel="Search No Results" customClass="SearchNoResultsCell" customModule="eduVPN" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="149.5" width="414" height="43.5"/>
+                                                        <rect key="frame" x="0.0" y="145.5" width="414" height="43.5"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UGc-9h-dOK" id="zj5-6d-z9M">
                                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -360,7 +360,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="a94-f2-5Xp" userLabel="Top Stack View">
-                                        <rect key="frame" x="87" y="0.0" width="240" height="121"/>
+                                        <rect key="frame" x="87" y="0.0" width="240" height="116"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9MY-sd-8O8" userLabel="Spacer">
                                                 <rect key="frame" x="0.0" y="0.0" width="240" height="20"/>
@@ -370,17 +370,17 @@
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Pj1-J0-oRP" userLabel="Header Stack View">
-                                                <rect key="frame" x="25.5" y="25" width="189.5" height="33"/>
+                                                <rect key="frame" x="33" y="25" width="174" height="28"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YqT-lQ-JKE" userLabel="Country Flag">
-                                                        <rect key="frame" x="0.0" y="7.5" width="24" height="18"/>
+                                                        <rect key="frame" x="0.0" y="5" width="24" height="18"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="24" id="RQ6-OR-kpI"/>
                                                             <constraint firstAttribute="height" constant="18" id="vzo-vC-GhH"/>
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Server Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dCe-Ed-8NS">
-                                                        <rect key="frame" x="34" y="0.0" width="155.5" height="33"/>
+                                                        <rect key="frame" x="34" y="0.0" width="140" height="28"/>
                                                         <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="24"/>
                                                         <color key="textColor" name="BoldUITextColor"/>
                                                         <nil key="highlightedColor"/>
@@ -388,7 +388,7 @@
                                                 </subviews>
                                             </stackView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="100" horizontalCompressionResistancePriority="850" scrollEnabled="NO" editable="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="R4m-ja-RFL">
-                                                <rect key="frame" x="56" y="63" width="128.5" height="33"/>
+                                                <rect key="frame" x="56" y="58" width="128.5" height="33"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <attributedString key="attributedText">
                                                     <fragment content="Support: Contacts">
@@ -402,7 +402,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aL6-Ly-9Ye" userLabel="Spacer">
-                                                <rect key="frame" x="0.0" y="101" width="240" height="20"/>
+                                                <rect key="frame" x="0.0" y="96" width="240" height="20"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="bAn-nx-8cC"/>
@@ -411,23 +411,23 @@
                                         </subviews>
                                     </stackView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="50" translatesAutoresizingMaskIntoConstraints="NO" id="SMW-WO-xIh" userLabel="Connection Status Image View">
-                                        <rect key="frame" x="182" y="224.5" width="50" height="71.5"/>
+                                        <rect key="frame" x="182" y="222.5" width="50" height="71.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="SMW-WO-xIh" secondAttribute="height" multiplier="7:10" id="b0u-IC-ndW"/>
                                             <constraint firstAttribute="height" relation="lessThanOrEqual" constant="110" id="rzI-cp-aJN"/>
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="dvC-ea-mDy" userLabel="Status Stack View">
-                                        <rect key="frame" x="130" y="399.5" width="154" height="51.5"/>
+                                        <rect key="frame" x="132" y="400.5" width="150" height="44.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Not Connected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rYc-lk-och" userLabel="Status Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="154" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="150" height="26"/>
                                                 <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="22"/>
                                                 <color key="textColor" name="RegularUITextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status detail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="37x-Tc-jAN" userLabel="Status Detail Label">
-                                                <rect key="frame" x="36.5" y="32" width="81" height="19.5"/>
+                                                <rect key="frame" x="36" y="28" width="78.5" height="16.5"/>
                                                 <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="14"/>
                                                 <color key="textColor" name="RegularUITextColor"/>
                                                 <nil key="highlightedColor"/>
@@ -435,7 +435,7 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sPB-kQ-Q1A" userLabel="VPN Switch Container">
-                                        <rect key="frame" x="0.0" y="554.5" width="414" height="40"/>
+                                        <rect key="frame" x="0.0" y="551.5" width="414" height="40"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WdD-o8-uaO">
                                                 <rect key="frame" x="172" y="5" width="70" height="30"/>
@@ -476,13 +476,13 @@
                                                                         <rect key="frame" x="0.0" y="1" width="394" height="44"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6zQ-9H-MHL">
-                                                                                <rect key="frame" x="0.0" y="11" width="48.5" height="22"/>
+                                                                                <rect key="frame" x="0.0" y="12.5" width="48.5" height="19"/>
                                                                                 <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                                                 <color key="textColor" name="BoldUITextColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="700" ambiguous="YES" text="Profile name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FSj-Ul-INY" userLabel="Profile name">
-                                                                                <rect key="frame" x="58.5" y="13" width="289.5" height="19.5"/>
+                                                                                <rect key="frame" x="58.5" y="14" width="289.5" height="16.5"/>
                                                                                 <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="14"/>
                                                                                 <color key="textColor" name="RegularUITextColor"/>
                                                                                 <nil key="highlightedColor"/>
@@ -568,7 +568,7 @@
                                                                 <rect key="frame" x="0.0" y="1" width="394" height="44"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connection Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh2-4E-W3r">
-                                                                        <rect key="frame" x="0.0" y="11" width="338" height="22"/>
+                                                                        <rect key="frame" x="0.0" y="12.5" width="338" height="19"/>
                                                                         <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                                         <color key="textColor" name="BoldUITextColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -782,7 +782,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
-                            <tableViewSection headerTitle="Options" footerTitle="Changes to this option will take effect from the next connection onwards" id="wTW-Kc-Fcu">
+                            <tableViewSection headerTitle="Options" footerTitle="Changes to this option will take effect from the next connection onwards." id="wTW-Kc-Fcu">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="F3y-FO-Jh4">
                                         <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
@@ -792,7 +792,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connect using TCP only" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Axm-hd-YwD">
-                                                    <rect key="frame" x="20" y="11" width="315" height="22"/>
+                                                    <rect key="frame" x="20" y="12.5" width="315" height="19"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -815,10 +815,43 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="Notifications" footerTitle="If enabled, a notification is triggered 30 mins before session expiry." id="3s3-yP-DD1">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="VZ3-o9-efz">
+                                        <rect key="frame" x="0.0" y="190.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VZ3-o9-efz" id="jLq-31-hCA">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Notify before session expiry" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HSr-1W-y5a">
+                                                    <rect key="frame" x="20" y="12.5" width="315" height="19"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
+                                                    <color key="textColor" name="RegularUITextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="bNV-hc-cFQ">
+                                                    <rect key="frame" x="345" y="6.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="sessionExpiryNotificationSwitchToggled:" destination="eWu-AC-nmd" eventType="valueChanged" id="0zS-WZ-drg"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="HSr-1W-y5a" firstAttribute="leading" secondItem="jLq-31-hCA" secondAttribute="leadingMargin" id="RV8-mr-bXi"/>
+                                                <constraint firstItem="bNV-hc-cFQ" firstAttribute="centerY" secondItem="jLq-31-hCA" secondAttribute="centerY" id="UNU-U4-GYM"/>
+                                                <constraint firstItem="bNV-hc-cFQ" firstAttribute="leading" secondItem="HSr-1W-y5a" secondAttribute="trailing" constant="10" id="aUJ-gW-ipL"/>
+                                                <constraint firstItem="HSr-1W-y5a" firstAttribute="centerY" secondItem="jLq-31-hCA" secondAttribute="centerY" id="f1U-qN-Fvh"/>
+                                                <constraint firstAttribute="trailing" secondItem="bNV-hc-cFQ" secondAttribute="trailing" constant="20" id="sKZ-Pw-XYt"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="Logging" id="UOS-N7-Rcv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="ybG-3O-5od">
-                                        <rect key="frame" x="0.0" y="183" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="318" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ybG-3O-5od" id="84I-6v-Tn8">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -839,7 +872,7 @@
                             <tableViewSection headerTitle="Import" id="RsF-JL-0Za">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="JVz-gK-yTg">
-                                        <rect key="frame" x="0.0" y="282.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="417.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JVz-gK-yTg" id="ppR-Rf-pES">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -864,21 +897,21 @@
                             <tableViewSection headerTitle="About" footerTitle="For license information, please see the source code." id="zZ8-eL-KFl">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="clE-jt-jh6" detailTextLabel="6Vz-Gx-mbB" style="IBUITableViewCellStyleValue1" id="2bw-6y-6xS">
-                                        <rect key="frame" x="0.0" y="389.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="524.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2bw-6y-6xS" id="gCV-zU-1zY">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="clE-jt-jh6">
-                                                    <rect key="frame" x="20" y="11" width="76.5" height="22"/>
+                                                    <rect key="frame" x="20" y="13" width="74" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Version number" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6Vz-Gx-mbB">
-                                                    <rect key="frame" x="273.5" y="11" width="120.5" height="22"/>
+                                                    <rect key="frame" x="282" y="13" width="112" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
@@ -888,21 +921,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Zsk-gl-9Hv" detailTextLabel="AyI-A2-tvn" style="IBUITableViewCellStyleValue1" id="4tU-D4-oc1">
-                                        <rect key="frame" x="0.0" y="433" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="568" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4tU-D4-oc1" id="8ys-ct-SxW">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Source code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zsk-gl-9Hv">
-                                                    <rect key="frame" x="20" y="11" width="92" height="22"/>
+                                                    <rect key="frame" x="20" y="13" width="91" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="https://github.com/eduvpn/apple" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" id="AyI-A2-tvn">
-                                                    <rect key="frame" x="145.5" y="11" width="248.5" height="22"/>
+                                                    <rect key="frame" x="157.5" y="13" width="236.5" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" systemColor="systemBlueColor"/>
@@ -922,6 +955,7 @@
                     <connections>
                         <outlet property="appNameLabel" destination="clE-jt-jh6" id="kcJ-tv-7Ri"/>
                         <outlet property="appVersionLabel" destination="6Vz-Gx-mbB" id="x2g-RM-YMO"/>
+                        <outlet property="sessionExpiryNotificationSwitch" destination="bNV-hc-cFQ" id="XCP-iW-Fnz"/>
                         <outlet property="useTCPOnlySwitch" destination="tzU-Bj-Q8h" id="ZcY-7u-WEc"/>
                     </connections>
                 </tableViewController>
@@ -971,7 +1005,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Vcr-vp-RKc">
-                                <rect key="frame" x="20" y="20" width="374" height="302"/>
+                                <rect key="frame" x="20" y="20" width="374" height="297"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cd1-ju-vIT" userLabel="Top Spacer">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="60"/>
@@ -994,13 +1028,13 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Server Address" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jkQ-7C-0j3">
-                                        <rect key="frame" x="97.5" y="181" width="179.5" height="33"/>
+                                        <rect key="frame" x="105" y="181" width="164.5" height="28"/>
                                         <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="24"/>
                                         <color key="textColor" name="BoldUITextColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Server URL" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ACm-mB-DCn">
-                                        <rect key="frame" x="20" y="226" width="334" height="34"/>
+                                        <rect key="frame" x="20" y="221" width="334" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL" returnKeyType="go" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no" textContentType="url"/>
                                         <connections>
@@ -1008,7 +1042,7 @@
                                         </connections>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JGc-id-Tai" userLabel="Add Server Button">
-                                        <rect key="frame" x="149" y="272" width="76" height="30"/>
+                                        <rect key="frame" x="149" y="267" width="76" height="30"/>
                                         <state key="normal" title="Add Server"/>
                                         <connections>
                                             <action selector="addServerTapped:" destination="QgS-AY-8Gr" eventType="touchUpInside" id="r8I-2C-ZbM"/>

--- a/EduVPN/Services/Environment.swift
+++ b/EduVPN/Services/Environment.swift
@@ -87,8 +87,8 @@ class Environment {
     #endif
 
     #if os(macOS)
-    func instantiatePreferencesViewController() -> PreferencesViewController {
-        let parameters = PreferencesViewController.Parameters(environment: self)
+    func instantiatePreferencesViewController(mainVC: MainViewController) -> PreferencesViewController {
+        let parameters = PreferencesViewController.Parameters(environment: self, mainVC: mainVC)
         return instantiate(PreferencesViewController.self, identifier: "Preferences", parameters: parameters)
     }
 

--- a/EduVPN/Services/Environment.swift
+++ b/EduVPN/Services/Environment.swift
@@ -21,6 +21,7 @@ class Environment {
     let persistenceService: PersistenceService
     let serverAPIService: ServerAPIService
     let connectionService: ConnectionServiceProtocol
+    let notificationService: NotificationService
 
     init(navigationController: NavigationController) {
         self.navigationController = navigationController
@@ -36,6 +37,8 @@ class Environment {
             configClientId: Config.shared.clientId)
         self.persistenceService = PersistenceService()
         self.serverAPIService = ServerAPIService(serverAuthService: serverAuthService)
+        self.notificationService = NotificationService()
+
         #if targetEnvironment(simulator)
         self.connectionService = MockConnectionService()
         #else

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -50,7 +50,7 @@ class NotificationService: NSObject {
         }
     }
 
-    func attemptSchedulingCertificateExpiryNotification(
+    func attemptSchedulingSessionExpiryNotification(
         expiryDate: Date, connectionAttemptId: UUID, from viewController: ViewController) -> Guarantee<Bool> {
 
         let userDefaults = UserDefaults.standard
@@ -68,7 +68,7 @@ class NotificationService: NSObject {
                             .then { isAuthorized in
                                 if isAuthorized {
                                     UserDefaults.standard.shouldNotifyBeforeSessionExpiry = true
-                                    return Self.scheduleCertificateExpiryNotification(
+                                    return Self.scheduleSessionExpiryNotification(
                                         expiryDate: expiryDate, connectionAttemptId: connectionAttemptId)
                                 } else {
                                     UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
@@ -86,7 +86,7 @@ class NotificationService: NSObject {
             return Self.requestAuthorization()
                 .then { isAuthorized in
                     if isAuthorized {
-                        return Self.scheduleCertificateExpiryNotification(
+                        return Self.scheduleSessionExpiryNotification(
                             expiryDate: expiryDate, connectionAttemptId: connectionAttemptId)
                     } else {
                         UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
@@ -100,12 +100,12 @@ class NotificationService: NSObject {
         }
     }
 
-    func descheduleCertificateExpiryNotifications() {
+    func descheduleSessionExpiryNotification() {
         Self.notificationCenter.removeAllPendingNotificationRequests()
         os_log("Certificate expiry notifications descheduled", log: Log.general, type: .debug)
     }
 
-    func enableCertificateExpiryNotification(from viewController: ViewController) -> Guarantee<Bool> {
+    func enableSessionExpiryNotification(from viewController: ViewController) -> Guarantee<Bool> {
         firstly {
             Self.requestAuthorization()
         }.map { isAuthorized in
@@ -119,7 +119,7 @@ class NotificationService: NSObject {
         }
     }
 
-    func disableCertificateExpiryNotification() {
+    func disableSessionExpiryNotification() {
         UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
     }
 
@@ -254,7 +254,7 @@ class NotificationService: NSObject {
         #endif
     }
 
-    private static func scheduleCertificateExpiryNotification(
+    private static func scheduleSessionExpiryNotification(
         expiryDate: Date, connectionAttemptId: UUID) -> Guarantee<Bool> {
 
         os_log("Certificate expires at %{public}@", log: Log.general, type: .debug, expiryDate as NSDate)
@@ -269,13 +269,13 @@ class NotificationService: NSObject {
             ((minutesToExpiry - maxMinutesFromNotificationToExpiry) * 60) : minSecondsToNotification
         precondition(secondsToNotification > 0)
 
-        return addCertificateExpiryNotificationRequest(
+        return addSessionExpiryNotificationRequest(
             notificationId: connectionAttemptId.uuidString,
             expiryDate: expiryDate,
             secondsToNotification: secondsToNotification)
     }
 
-    private static func addCertificateExpiryNotificationRequest(
+    private static func addSessionExpiryNotificationRequest(
         notificationId: String,
         expiryDate: Date,
         secondsToNotification: Int) -> Guarantee<Bool> {
@@ -307,9 +307,9 @@ class NotificationService: NSObject {
         return Guarantee<Bool> { callback in
             notificationCenter.add(request) { error in
                 if let error = error {
-                    os_log("Error scheduling certificate expiry notification: %{public}@", log: Log.general, type: .error, error.localizedDescription)
+                    os_log("Error scheduling session expiry notification: %{public}@", log: Log.general, type: .error, error.localizedDescription)
                 } else {
-                    os_log("Certificate expiry notification scheduled to fire in %{public}d seconds", log: Log.general, type: .debug, secondsToNotification)
+                    os_log("Session expiry notification scheduled to fire in %{public}d seconds", log: Log.general, type: .debug, secondsToNotification)
                 }
                 callback(error == nil)
             }

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -199,7 +199,7 @@ class NotificationService: NSObject {
                 "You can change this option later in Settings",
                 comment: ""),
             preferredStyle: .alert)
-        return Guarentee<Bool> { callback in
+        return Guarantee<Bool> { callback in
             let refreshAction = UIAlertAction(title: NSLocalizedString("Notify", comment: ""),
                                               style: .default,
                                               handler: { _ in callback(true) })
@@ -243,7 +243,7 @@ class NotificationService: NSObject {
             format: NSLocalizedString(
                 "Notifications are disabled for %@", comment: ""),
             appName)
-        var message = String(
+        let message = String(
             format: NSLocalizedString(
                 "Please enable notifications for ‘%@’ in Settings > %@ > Notifications",
                 comment: ""),

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -264,9 +264,9 @@ class NotificationService: NSObject {
         let minutesToExpiry = Calendar.current.dateComponents([.minute], from: Date(), to: expiryDate).minute ?? 0
 
         // Normally, fire the notification 30 mins before expiry. If we're already past
-        // that time, fire it 2 seconds from now.
+        // that time, fire it 5 seconds from now.
         let maxMinutesFromNotificationToExpiry = 30
-        let minSecondsToNotification = 2
+        let minSecondsToNotification = 5
         let secondsToNotification = (minutesToExpiry > maxMinutesFromNotificationToExpiry) ?
             ((minutesToExpiry - maxMinutesFromNotificationToExpiry) * 60) : minSecondsToNotification
         precondition(secondsToNotification > 0)

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -1,0 +1,309 @@
+//
+//  NotificationService.swift
+//  EduVPN
+
+// Handles local user notifications delivered from/to the app
+
+import Foundation
+import UserNotifications
+import PromiseKit
+import os.log
+
+// swiftlint:disable:next type_body_length
+class NotificationService {
+    enum NotificationCategory: String {
+        case certificateExpiry
+    }
+
+    enum SessionExpiryNotificationAction: String {
+        case renewSession
+    }
+
+    private static var notificationCenter: UNUserNotificationCenter {
+        UNUserNotificationCenter.current()
+    }
+
+    private static var authorizationOptions: UNAuthorizationOptions = [.alert, .sound]
+
+    init() {
+        self.setNotificiationCategories()
+        if UserDefaults.standard.hasAskedUserOnNotifyBeforeSessionExpiry &&
+               UserDefaults.standard.shouldNotifyBeforeSessionExpiry {
+            // Make sure we have permissions to show notifications.
+            // Ideally, this shouldn't trigger the OS prompt.
+            firstly {
+                Self.requestAuthorization()
+            }.done { isAuthorized in
+                if !isAuthorized {
+                    UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
+                }
+            }
+        }
+    }
+
+    func attemptSchedulingCertificateExpiryNotification(
+        expiryDate: Date, connectionAttemptId: UUID, from viewController: ViewController) -> Guarantee<Bool> {
+
+        let userDefaults = UserDefaults.standard
+
+        if !userDefaults.hasAskedUserOnNotifyBeforeSessionExpiry && !userDefaults.shouldNotifyBeforeSessionExpiry {
+            // We haven't shown the prompt, and user hasn't enabled
+            // notifications in Preferences.
+            // Ask the user with a prompt first, then if the user approves,
+            // attempt to schedule notifications.
+            return Self.showPrePrompt(from: viewController)
+                .then { isUserWantsToBeNotified in
+                    UserDefaults.standard.hasAskedUserOnNotifyBeforeSessionExpiry = true
+                    if isUserWantsToBeNotified {
+                        return Self.requestAuthorization()
+                            .then { isAuthorized in
+                                if isAuthorized {
+                                    UserDefaults.standard.shouldNotifyBeforeSessionExpiry = true
+                                    return Self.scheduleCertificateExpiryNotification(
+                                        expiryDate: expiryDate, connectionAttemptId: connectionAttemptId)
+                                } else {
+                                    UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
+                                    Self.showNotificationsDisabledAlert(from: viewController)
+                                    return Guarantee<Bool>.value(false)
+                                }
+                            }
+                    } else {
+                        return Guarantee<Bool>.value(false)
+                    }
+                }
+        } else if userDefaults.shouldNotifyBeforeSessionExpiry {
+            // User has chosen to be notified.
+            // Attempt to schedule notification.
+            return Self.requestAuthorization()
+                .then { isAuthorized in
+                    if isAuthorized {
+                        return Self.scheduleCertificateExpiryNotification(
+                            expiryDate: expiryDate, connectionAttemptId: connectionAttemptId)
+                    } else {
+                        UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
+                        return Guarantee<Bool>.value(false)
+                    }
+                }
+        } else {
+            // User has chosen to be not notified.
+            // Do nothing.
+            return Guarantee<Bool>.value(false)
+        }
+    }
+
+    func descheduleCertificateExpiryNotifications() {
+        Self.notificationCenter.removeAllPendingNotificationRequests()
+        os_log("Certificate expiry notifications descheduled", log: Log.general, type: .debug)
+    }
+
+    func enableCertificateExpiryNotification(from viewController: ViewController) -> Guarantee<Bool> {
+        firstly {
+            Self.requestAuthorization()
+        }.map { isAuthorized in
+            if isAuthorized {
+                UserDefaults.standard.shouldNotifyBeforeSessionExpiry = true
+            } else {
+                UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
+                Self.showNotificationsDisabledAlert(from: viewController)
+            }
+            return isAuthorized
+        }
+    }
+
+    func disableCertificateExpiryNotification() {
+        UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
+    }
+
+    private func setNotificiationCategories() {
+        let authorizeAction = UNNotificationAction(
+            identifier: SessionExpiryNotificationAction.renewSession.rawValue,
+            title: NSString.localizedUserNotificationString(forKey: "Renew Session", arguments: nil),
+            options: [.authenticationRequired, .foreground])
+        let notificationActions = [authorizeAction]
+        let certificateExpiryCategory = UNNotificationCategory(
+            identifier: NotificationCategory.certificateExpiry.rawValue,
+            actions: notificationActions,
+            intentIdentifiers: [],
+            hiddenPreviewsBodyPlaceholder: "",
+            options: [])
+        Self.notificationCenter.setNotificationCategories([certificateExpiryCategory])
+    }
+
+    private static func requestAuthorization() -> Guarantee<Bool> {
+        os_log("Requesting authorization for notifications", log: Log.general, type: .info)
+        return Guarantee<Bool> { callback in
+            notificationCenter.requestAuthorization(options: authorizationOptions) { (granted, error) in
+                if granted {
+                    os_log("Notifications authorized", log: Log.general, type: .info)
+                } else {
+                    os_log("Notifications not authorized", log: Log.general, type: .info)
+                }
+
+                if let error = error {
+                    os_log("Error occured when requesting notification authorization. %{public}@", log: Log.general, type: .error, error.localizedDescription)
+                }
+                callback(granted)
+            }
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    private static func showPrePrompt(from viewController: ViewController) -> Guarantee<Bool> {
+
+        #if os(macOS)
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = NSLocalizedString(
+            "Would you like to be notified when the current session is about to expire?",
+            comment: "")
+        alert.informativeText = NSLocalizedString(
+            "You can change this option later in Preferences",
+            comment: "")
+        alert.addButton(withTitle: NSLocalizedString("Notify", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Don’t Notify", comment: ""))
+        if let window = viewController.view.window {
+            return Guarantee<Bool> { callback in
+                alert.beginSheetModal(for: window) { result in
+                    if case .alertFirstButtonReturn = result {
+                        NSLog("Callback true")
+                        callback(true)
+                    } else {
+                        NSLog("Callback false")
+                        callback(false)
+                    }
+                }
+            }
+        } else {
+            return Guarantee<Bool>.value(false)
+        }
+
+        #elseif os(iOS)
+
+        let alert = UIAlertController(
+            title: NSLocalizedString(
+                "Would you like to be notified when the current session is about to expire?",
+                comment: ""),
+            message: NSLocalizedString(
+                "You can change this option later in Settings",
+                comment: ""),
+            preferredStyle: .alert)
+        return Guarentee<Bool> { callback in
+            let refreshAction = UIAlertAction(title: NSLocalizedString("Notify", comment: ""),
+                                              style: .default,
+                                              handler: { _ in callback(true) })
+            let cancelAction = UIAlertAction(title: NSLocalizedString("Don’t Notify", comment: ""),
+                                             style: .cancel,
+                                             handler: { _ in callback(false) })
+            alert.addAction(refreshAction)
+            alert.addAction(cancelAction)
+            viewController.present(alert, animated: true, completion: nil)
+        }
+
+        #endif
+    }
+
+    private static func showNotificationsDisabledAlert(from viewController: ViewController) {
+
+        let appName = Config.shared.appName
+
+        #if os(macOS)
+
+        let alert = NSAlert()
+        alert.messageText = String(
+            format: NSLocalizedString(
+                "Notifications are disabled for %@", comment: ""),
+            appName)
+        alert.informativeText = String(
+            format: NSLocalizedString(
+                "Please enable notifications for ‘%@’ in System Preferences > Notifications > %@",
+                comment: ""),
+            appName, appName)
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = viewController.view.window {
+            alert.beginSheetModal(for: window)
+        } else {
+            alert.runModal()
+        }
+
+        #elseif os(iOS)
+
+        let title = String(
+            format: NSLocalizedString(
+                "Notifications are disabled for %@", comment: ""),
+            appName)
+        var message = String(
+            format: NSLocalizedString(
+                "Please enable notifications for ‘%@’ in Settings > %@ > Notifications",
+                comment: ""),
+            appName, appName)
+        let okAction = UIAlertAction(title: "OK", style: .default)
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(okAction)
+        viewController.present(alert, animated: true, completion: nil)
+
+        #endif
+    }
+
+    private static func scheduleCertificateExpiryNotification(
+        expiryDate: Date, connectionAttemptId: UUID) -> Guarantee<Bool> {
+
+        os_log("Certificate expires at %{public}@", log: Log.general, type: .debug, expiryDate as NSDate)
+
+        let minutesToExpiry = Calendar.current.dateComponents([.minute], from: Date(), to: expiryDate).minute ?? 0
+
+        // Normally, fire the notification 30 mins before expiry. If we're already past
+        // that time, fire it 2 seconds from now.
+        let maxMinutesFromNotificationToExpiry = 30
+        let minSecondsToNotification = 2
+        let secondsToNotification = (minutesToExpiry > maxMinutesFromNotificationToExpiry) ?
+            ((minutesToExpiry - maxMinutesFromNotificationToExpiry) * 60) : minSecondsToNotification
+        precondition(secondsToNotification > 0)
+
+        return addCertificateExpiryNotificationRequest(
+            notificationId: connectionAttemptId.uuidString,
+            expiryDate: expiryDate,
+            secondsToNotification: secondsToNotification)
+    }
+
+    private static func addCertificateExpiryNotificationRequest(
+        notificationId: String,
+        expiryDate: Date,
+        secondsToNotification: Int) -> Guarantee<Bool> {
+
+        let content = UNMutableNotificationContent()
+        content.title = NSString.localizedUserNotificationString(
+            forKey: "Your VPN session is expiring",
+            arguments: nil)
+
+        // We're not using localizedUserNotificationString below becuse:
+        //   - we need the timestamp to be as per the current locale and
+        //     consistent with language of the body string
+        //   - when arguments: is not nil, the notifications don't seem to fire.
+        //     See: https://openradar.appspot.com/43007245
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        content.body = String(
+            format: NSLocalizedString("Session expires at %@", comment: ""),
+            formatter.string(from: expiryDate))
+
+        content.sound = UNNotificationSound.default
+
+        content.categoryIdentifier = NotificationCategory.certificateExpiry.rawValue
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(secondsToNotification), repeats: false)
+        let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: trigger)
+
+        return Guarantee<Bool> { callback in
+            notificationCenter.add(request) { error in
+                if let error = error {
+                    os_log("Error scheduling certificate expiry notification: %{public}@", log: Log.general, type: .error, error.localizedDescription)
+                } else {
+                    os_log("Certificate expiry notification scheduled to fire in %{public}d seconds", log: Log.general, type: .debug, secondsToNotification)
+                }
+                callback(error == nil)
+            }
+        }
+    }
+}

--- a/EduVPN/Shims/NavigationController.swift
+++ b/EduVPN/Shims/NavigationController.swift
@@ -122,10 +122,8 @@ extension NavigationController: Navigating {
 extension NavigationController {
     func presentPreferences() {
         guard let environment = environment else { return }
-        let preferencesVC = environment.instantiatePreferencesViewController()
-        if let mainVC = children.first as? MainViewController {
-            preferencesVC.delegate = mainVC
-        }
+        guard let mainVC = self.children.first as? MainViewController else { return }
+        let preferencesVC = environment.instantiatePreferencesViewController(mainVC: mainVC)
         presentedPreferencesVC = preferencesVC
         presentAsSheet(preferencesVC)
     }

--- a/EduVPN/Shims/NavigationController.swift
+++ b/EduVPN/Shims/NavigationController.swift
@@ -271,7 +271,7 @@ class NavigationController: UINavigationController {
 extension NavigationController {
     func showAlert(for error: Error) {
         let title = error.alertSummary
-        var message = error.alertDetail
+        let message = error.alertDetail
         let okAction = UIAlertAction(title: "OK", style: .default)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(okAction)

--- a/EduVPN/Shims/NavigationController.swift
+++ b/EduVPN/Shims/NavigationController.swift
@@ -123,6 +123,9 @@ extension NavigationController {
     func presentPreferences() {
         guard let environment = environment else { return }
         let preferencesVC = environment.instantiatePreferencesViewController()
+        if let mainVC = children.first as? MainViewController {
+            preferencesVC.delegate = mainVC
+        }
         presentedPreferencesVC = preferencesVC
         presentAsSheet(preferencesVC)
     }

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -484,6 +484,19 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
         self.connectionInfoHelper = nil
         self.connectionInfo = nil
     }
+
+    func scheduleSessionExpiryNotificationOnActiveVPN() -> Guarantee<Bool> {
+        guard connectionService.isInitialized else { return Guarantee<Bool>.value(false) }
+        guard connectionService.isVPNEnabled else { return Guarantee<Bool>.value(false) }
+        guard connectableInstance is ServerInstance else { return Guarantee<Bool>.value(false) }
+        if let connectionAttemptId = connectionService.connectionAttemptId,
+           let expiryDate = certificateExpiryHelper?.expiresAt,
+           let notificationService = notificationService {
+            return notificationService.scheduleSessionExpiryNotification(
+                expiryDate: expiryDate, connectionAttemptId: connectionAttemptId)
+        }
+        return Guarantee<Bool>.value(false)
+    }
 }
 
 private extension ConnectionViewModel {

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -388,7 +388,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
             guard let notificationService = self.notificationService else {
                 return Promise.value(())
             }
-            return notificationService.attemptSchedulingCertificateExpiryNotification(
+            return notificationService.attemptSchedulingSessionExpiryNotification(
                 expiryDate: expiresAt, connectionAttemptId: connectionAttemptId, from: viewController)
                 .map { _ in }
         }.ensure {
@@ -446,7 +446,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
             self.internalState = .disableVPNRequested
             return self.connectionService.disableVPN()
         }.map {
-            self.notificationService?.descheduleCertificateExpiryNotifications()
+            self.notificationService?.descheduleSessionExpiryNotification()
         }.ensure {
             self.internalState = self.connectionService.isVPNEnabled ? .enabledVPN : .idle
             if self.internalState == .idle {

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -202,6 +202,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
 
     private let connectableInstance: ConnectableInstance
     private let connectionService: ConnectionServiceProtocol
+    private let notificationService: NotificationService?
     private let serverDisplayInfo: ServerDisplayInfo
 
     private let serverAPIService: ServerAPIService?
@@ -216,6 +217,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
 
     init(server: ServerInstance,
          connectionService: ConnectionServiceProtocol,
+         notificationService: NotificationService,
          serverDisplayInfo: ServerDisplayInfo,
          serverAPIService: ServerAPIService,
          authURLTemplate: String?,
@@ -223,6 +225,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
 
         self.connectableInstance = server
         self.connectionService = connectionService
+        self.notificationService = notificationService
         self.serverDisplayInfo = serverDisplayInfo
         self.serverAPIService = serverAPIService
         self.authURLTemplate = authURLTemplate
@@ -259,6 +262,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
 
         self.connectableInstance = vpnConfigInstance
         self.connectionService = connectionService
+        self.notificationService = nil
         self.serverDisplayInfo = serverDisplayInfo
         self.serverAPIService = nil
         self.authURLTemplate = nil
@@ -355,11 +359,13 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 for: server, serverInfo: serverInfo, profile: profile,
                 from: viewController, wayfSkippingInfo: wayfSkippingInfo(),
                 options: serverAPIOptions)
-        }.then { tunnelConfigData -> Promise<Void> in
+        }.then { tunnelConfigData -> Promise<(Date, UUID)> in
             self.internalState = .enableVPNRequested
+            let validFrom = tunnelConfigData.certificateValidityRange.validFrom
+            let expiresAt = tunnelConfigData.certificateValidityRange.expiresAt
             self.certificateExpiryHelper = CertificateExpiryHelper(
-                validFrom: tunnelConfigData.certificateValidityRange.validFrom,
-                expiresAt: tunnelConfigData.certificateValidityRange.expiresAt,
+                validFrom: validFrom,
+                expiresAt: expiresAt,
                 handler: { [weak self] certificateStatus in
                     self?.certificateStatus = certificateStatus
                 })
@@ -377,6 +383,14 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 credentials: nil,
                 shouldDisableVPNOnError: true,
                 shouldPreventAutomaticConnections: false)
+                .map { (expiresAt, connectionAttemptId) }
+        }.then { (expiresAt, connectionAttemptId) -> Promise<Void> in
+            guard let notificationService = self.notificationService else {
+                return Promise.value(())
+            }
+            return notificationService.attemptSchedulingCertificateExpiryNotification(
+                expiryDate: expiresAt, connectionAttemptId: connectionAttemptId, from: viewController)
+                .map { _ in }
         }.ensure {
             self.internalState = self.connectionService.isVPNEnabled ? .enabledVPN : .idle
         }
@@ -431,6 +445,8 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
         return firstly { () -> Promise<Void> in
             self.internalState = .disableVPNRequested
             return self.connectionService.disableVPN()
+        }.map {
+            self.notificationService?.descheduleCertificateExpiryNotifications()
         }.ensure {
             self.internalState = self.connectionService.isVPNEnabled ? .enabledVPN : .idle
             if self.internalState == .idle {


### PR DESCRIPTION
Reintroducing "Your session is about to expire" local notifications in macOS and iOS. 

This was previously implemented in PR #282 but that implementation was removed in the redesigned app. This new implementation introduces a preferences checkbox and a pre-confirmation dialog.

Fixes #90.
