### PR TITLE
macOS: Improve HTML page shown after OAuth authentication completes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - iOS: Support for password-based OpenVPN configs
 - macOS: Can press return to connect when prompted for password
 - Rollback prevention for discovery data
+- macOS: Improve HTML page shown after OAuth authentication completes #182
 
 ## 2.2.2
 

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -39,7 +39,8 @@
 		6F36A71F24B5A36E00BA8F5E /* MainSecureInternetSectionHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F36A71E24B5A36E00BA8F5E /* MainSecureInternetSectionHeaderCell.swift */; };
 		6F36A79B24B6ED5D00BA8F5E /* SearchViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F36A79A24B6ED5D00BA8F5E /* SearchViewController+macOS.swift */; };
 		6F36A79D24B6F5BA00BA8F5E /* MainViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F36A79C24B6F5BA00BA8F5E /* MainViewController+macOS.swift */; };
-		6F42B1A624E333A800800FAC /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		6F42B1A624E333A800800FAC /* (null) in Sources */ = {isa = PBXBuildFile; };
+		6F49FAB5263C1A56005DB8D3 /* OAuthRedirectHTTPHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F49FAAB263C1A55005DB8D3 /* OAuthRedirectHTTPHandler.m */; };
 		6F4C1ED525D12D710042AD95 /* SharedTunnelOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4C1ED425D12D710042AD95 /* SharedTunnelOptions.swift */; };
 		6F4C1ED625D12D710042AD95 /* SharedTunnelOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4C1ED425D12D710042AD95 /* SharedTunnelOptions.swift */; };
 		6F50408D254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F50408C254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift */; };
@@ -329,6 +330,9 @@
 		6F36A71E24B5A36E00BA8F5E /* MainSecureInternetSectionHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSecureInternetSectionHeaderCell.swift; sourceTree = "<group>"; };
 		6F36A79A24B6ED5D00BA8F5E /* SearchViewController+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchViewController+macOS.swift"; sourceTree = "<group>"; };
 		6F36A79C24B6F5BA00BA8F5E /* MainViewController+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+macOS.swift"; sourceTree = "<group>"; };
+		6F49FAA9263C1A54005DB8D3 /* EduVPN-macOS-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EduVPN-macOS-Bridging-Header.h"; sourceTree = "<group>"; };
+		6F49FAAA263C1A55005DB8D3 /* OAuthRedirectHTTPHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OAuthRedirectHTTPHandler.h; sourceTree = "<group>"; };
+		6F49FAAB263C1A55005DB8D3 /* OAuthRedirectHTTPHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAuthRedirectHTTPHandler.m; sourceTree = "<group>"; };
 		6F4C1ED425D12D710042AD95 /* SharedTunnelOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTunnelOptions.swift; sourceTree = "<group>"; };
 		6F50408C254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionViewModel+SupportContact.swift"; sourceTree = "<group>"; };
 		6F54C92C25E033EE00A42C8F /* AddServerViewController+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddServerViewController+macOS.swift"; sourceTree = "<group>"; };
@@ -764,6 +768,15 @@
 			path = iOS;
 			sourceTree = "<group>";
 		};
+		6F49FAA8263C1A18005DB8D3 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				6F49FAAA263C1A55005DB8D3 /* OAuthRedirectHTTPHandler.h */,
+				6F49FAAB263C1A55005DB8D3 /* OAuthRedirectHTTPHandler.m */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
 		6F56BD7625A32797003FC282 /* Config */ = {
 			isa = PBXGroup;
 			children = (
@@ -950,6 +963,7 @@
 			isa = PBXGroup;
 			children = (
 				C7DB4B6A247FC198009932B1 /* AppDelegate.swift */,
+				6F49FAA9263C1A54005DB8D3 /* EduVPN-macOS-Bridging-Header.h */,
 				C7DB4BFF24804D62009932B1 /* Config */,
 				C7DB4B34247FBB06009932B1 /* Controllers */,
 				6FEF30F924A317940026C786 /* Views */,
@@ -984,6 +998,7 @@
 		C7DB4BD124803B57009932B1 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				6F49FAA8263C1A18005DB8D3 /* Mac */,
 				6FA8089424E6A75C00E7D924 /* MigrationHelper.swift */,
 				6FADF83024ADF86600B75E8D /* Log.swift */,
 				6FADF82E24ADF85F00B75E8D /* Crypto.swift */,
@@ -1817,6 +1832,7 @@
 				6FE1D11B24CD952C002D3D0C /* ConnectionInfoHelper.swift in Sources */,
 				6F05E64224D0A6AA008292F6 /* ErrorHandling.swift in Sources */,
 				6F59A58B24F67CE500560155 /* OAuthExternalUserAgent.swift in Sources */,
+				6F49FAB5263C1A56005DB8D3 /* OAuthRedirectHTTPHandler.m in Sources */,
 				6FEF30FF24A325860026C786 /* RowCell.swift in Sources */,
 				6FADF83124ADF86700B75E8D /* Log.swift in Sources */,
 				6FEF313B24A717570026C786 /* ServerAuthService.swift in Sources */,
@@ -2337,6 +2353,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = EduVPN/Resources/Mac/eduVPN.entitlements;
@@ -2386,6 +2403,8 @@
 				PRODUCT_NAME = "$(APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "EduVPN/EduVPN-macOS-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -2396,6 +2415,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = EduVPN/Resources/Mac/eduVPN.entitlements;
@@ -2444,6 +2464,7 @@
 				PRODUCT_NAME = "$(APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "EduVPN/EduVPN-macOS-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/EduVPN/EduVPN-macOS-Bridging-Header.h
+++ b/EduVPN/EduVPN-macOS-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "OAuthRedirectHTTPHandler.h"

--- a/EduVPN/Helpers/Mac/OAuthRedirectHTTPHandler.h
+++ b/EduVPN/Helpers/Mac/OAuthRedirectHTTPHandler.h
@@ -1,0 +1,15 @@
+//
+//  OAuthRedirectHTTPHandler.h
+//  EduVPN
+//
+
+#ifndef OAuthRedirectHTTPHandler_h
+#define OAuthRedirectHTTPHandler_h
+
+#import <Foundation/Foundation.h>
+#import <AppAuth/AppAuth.h>
+
+@interface OAuthRedirectHTTPHandler: OIDRedirectHTTPHandler
+@end
+
+#endif /* OAuthRedirectHTTPHandler_h */

--- a/EduVPN/Helpers/Mac/OAuthRedirectHTTPHandler.m
+++ b/EduVPN/Helpers/Mac/OAuthRedirectHTTPHandler.m
@@ -1,0 +1,144 @@
+//
+//  OAuthRedirectHTTPHandler.m
+//  EduVPN
+//
+//  Derived from OIDRedirectHTTPHandler.m in the AppAuth iOS SDK
+//
+//  Copyright 2016 Google Inc.
+//  Copyright 2021 The Commons Conservancy
+//  All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "OAuthRedirectHTTPHandler.h"
+#import "OIDLoopbackHTTPServer.h"
+
+static NSString *const kHTMLPageTemplate = @""
+    "<!DOCTYPE html>"
+    "<html lang=\"en\" dir=\"ltr\" xmlns=\"http://www.w3.org/1999/xhtml\">"
+    "<head>"
+    "    <meta charset=\"utf-8\" />"
+    "    <title>%@</title>"
+    "    <style>"
+    "body {"
+    "    font-family: -apple-system, BlinkMacSystemFont, \"Avenir Next\", Avenir,"
+    "                 \"Nimbus Sans L\", Roboto, Noto, \"Segoe UI\", Arial,"
+    "                 Helvetica, \"Helvetica Neue\", sans-serif;"
+    "    margin: 0;"
+    "    height: 100vh;"
+    "    display: flex;"
+    "    align-items: center;"
+    "    justify-content: center;"
+    "    background: #ccc;"
+    "    color: #888;"
+    "}"
+    "main {"
+    "    padding: 1em 2em;"
+    "    text-align: center;"
+    "    border: 1pt solid #666;"
+    "    box-shadow: rgba(0, 0, 0, 0.2) 0px 1px 4px;"
+    "    border-color: #aaa;"
+    "    background: #ddd;"
+    "}"
+    "    </style>"
+    "</head>"
+    "<body class=\"finished\">"
+    "    <main>"
+    "        <h2>%@</h2>"
+    "        <p>%@</p>"
+    "    </main>"
+    "</body>"
+    "</html>";
+
+static NSString *const kStringsAuthorizationComplete[] =
+    {
+        @"Authorization Successful",
+        @"The client authorized succesfully",
+        @"You can now close this tab."
+    };
+
+static NSString *const kStringsErrorMissingCurrentAuthorizationFlow[] =
+    {
+        @"Authorization Error",
+        @"Authorization Error",
+        @"AppAuth Error: No <code>currentAuthorizationFlow</code> is set on the "
+         "<code>OIDRedirectHTTPHandler</code>. Cannot process redirect."
+    };
+
+static NSString *const kStringsErrorRedirectNotValid[] =
+    {
+        @"Authorization Error",
+        @"Authorization Error",
+        @"AppAuth Error: Not a valid redirect."
+    };
+
+@implementation OAuthRedirectHTTPHandler
+
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
+- (void)HTTPConnection:(HTTPConnection *)conn didReceiveRequest:(HTTPServerRequest *)mess {
+  // Sends URL to AppAuth.
+  CFURLRef url = CFHTTPMessageCopyRequestURL(mess.request);
+  BOOL handled = [[self currentAuthorizationFlow] resumeExternalUserAgentFlowWithURL:(__bridge NSURL *)url];
+
+  // Stops listening to further requests after the first valid authorization response.
+  if (handled) {
+      [self setCurrentAuthorizationFlow: nil];
+      if ([self respondsToSelector:@selector(stopHTTPListener)]) {
+          [self performSelector:@selector(stopHTTPListener)];
+      }
+  }
+
+  NSString *bodyText = @"";
+  NSInteger httpResponseCode = 0;
+
+  if (handled) {
+    bodyText = [NSString stringWithFormat:kHTMLPageTemplate,
+                kStringsAuthorizationComplete[0],
+                kStringsAuthorizationComplete[1],
+                kStringsAuthorizationComplete[2]];
+    httpResponseCode = 200;
+  } else if ([self currentAuthorizationFlow]) {
+    bodyText = [NSString stringWithFormat:kHTMLPageTemplate,
+                kStringsErrorMissingCurrentAuthorizationFlow[0],
+                kStringsErrorMissingCurrentAuthorizationFlow[1],
+                kStringsErrorMissingCurrentAuthorizationFlow[2]];
+    httpResponseCode = 404;
+  } else {
+    bodyText = [NSString stringWithFormat:kHTMLPageTemplate,
+                kStringsErrorRedirectNotValid[0],
+                kStringsErrorRedirectNotValid[1],
+                kStringsErrorRedirectNotValid[2]];
+    httpResponseCode = 400;
+  }
+
+  NSAssert([bodyText length] > 0, @"bodyText is empty");
+  NSAssert(httpResponseCode > 0, @"httpResponseCode is %ld, should be greater than 0", (long) httpResponseCode);
+
+  NSData *data = [bodyText dataUsingEncoding:NSUTF8StringEncoding];
+
+  CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault,
+                                                          httpResponseCode,
+                                                          NULL,
+                                                          kCFHTTPVersion1_1);
+  CFHTTPMessageSetHeaderFieldValue(response,
+                                   (__bridge CFStringRef)@"Content-Length",
+                                   (__bridge CFStringRef)[NSString stringWithFormat:@"%lu",
+                                       (unsigned long)data.length]);
+  CFHTTPMessageSetBody(response, (__bridge CFDataRef)data);
+
+  [mess setResponse:response];
+  CFRelease(response);
+}
+
+@end

--- a/EduVPN/Services/ServerAuthService.swift
+++ b/EduVPN/Services/ServerAuthService.swift
@@ -32,7 +32,7 @@ class ServerAuthService {
     private var currentAuthFlow: OIDExternalUserAgentSession?
 
     #if os(macOS)
-    private lazy var redirectHttpHandler = OIDRedirectHTTPHandler(successURL: nil)
+    private lazy var redirectHttpHandler = OAuthRedirectHTTPHandler(successURL: nil)
     #endif
 
     var redirectURL: URL {


### PR DESCRIPTION
Fixes #182.

We need to override a method in `OIDRedirectHTTPHandler` that's not in its interface, so this PR implements a subclass of `OIDRedirectHTTPHandler` in Objective-C and re-implements that method. This can't be done in Swift because the method we want to override is not part of the interface.
