### PR TITLE
Introduce support for eduVPN Server APIv3

### DIFF
--- a/EduVPN-Tests-iOS/EduVPNTestsiOS.swift
+++ b/EduVPN-Tests-iOS/EduVPNTestsiOS.swift
@@ -2,8 +2,7 @@
 //  EduVPN_Tests_iOS.swift
 //  EduVPN-Tests-iOS
 //
-//  Created by Johan Kool on 09/12/2020.
-//  Copyright © 2020 SURFNet. All rights reserved.
+//  Copyright © 2020-2021 The Commons Conservancy. All rights reserved.
 //
 
 import XCTest

--- a/EduVPN-UITests-iOS/EduVPNUITestsiOS.swift
+++ b/EduVPN-UITests-iOS/EduVPNUITestsiOS.swift
@@ -2,8 +2,7 @@
 //  EduVPN_UITests_iOS.swift
 //  EduVPN-UITests-iOS
 //
-//  Created by Johan Kool on 09/12/2020.
-//  Copyright © 2020 SURFNet. All rights reserved.
+//  Copyright © 2020-2021 The Commons Conservancy. All rights reserved.
 //
 
 import XCTest

--- a/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
+++ b/EduVPN-UITests-macOS/EduVPNUITestsmacOS.swift
@@ -2,8 +2,7 @@
 //  EduVPN_UITests_macOS.swift
 //  EduVPN-UITests-macOS
 //
-//  Created by Johan Kool on 16/12/2020.
-//  Copyright © 2020 SURFNet. All rights reserved.
+//  Copyright © 2020-2021 The Commons Conservancy. All rights reserved.
 //
 
 import XCTest

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -1767,7 +1767,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "export PATH=${PATH}:/usr/local/bin:/opt/homebrew/bin\nif which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed (Run: 'brew install swiftlint')\"\nfi\n";
 		};
 		6F750C8D24975A4300AF2C04 /* Set Build Number */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -2436,7 +2436,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4ABCCBE621E528260020CB6D /* Development-OpenVPNTunnelExtension.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -2466,7 +2466,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4ABCCBE521E528140020CB6D /* Release-OpenVPNTunnelExtension.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -2761,6 +2761,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6F66DB7E265E50BB006974CF /* Development-WireGuardTunnelExtension.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
@@ -2793,6 +2794,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6F66DB7D265E50BB006974CF /* Release-WireGuardTunnelExtension.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		6F4C1ED625D12D710042AD95 /* SharedTunnelOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4C1ED425D12D710042AD95 /* SharedTunnelOptions.swift */; };
 		6F50408D254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F50408C254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift */; };
 		6F50408E254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F50408C254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift */; };
+		6F50CEBA2679E3C4008A38BA /* ServerAPIv3Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F50CEB92679E3C4008A38BA /* ServerAPIv3Handler.swift */; };
+		6F50CEBB2679E3C4008A38BA /* ServerAPIv3Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F50CEB92679E3C4008A38BA /* ServerAPIv3Handler.swift */; };
 		6F54C92225DFE1B100A42C8F /* AddServerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F65629725D9AEB100ED3ECC /* AddServerViewController.swift */; };
 		6F54C92D25E033EE00A42C8F /* AddServerViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F54C92C25E033EE00A42C8F /* AddServerViewController+macOS.swift */; };
 		6F54C93825E0359200A42C8F /* AddServerViewController+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F54C93725E0359200A42C8F /* AddServerViewController+iOS.swift */; };
@@ -382,6 +384,7 @@
 		6F49FAAB263C1A55005DB8D3 /* OAuthRedirectHTTPHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OAuthRedirectHTTPHandler.m; sourceTree = "<group>"; };
 		6F4C1ED425D12D710042AD95 /* SharedTunnelOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTunnelOptions.swift; sourceTree = "<group>"; };
 		6F50408C254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionViewModel+SupportContact.swift"; sourceTree = "<group>"; };
+		6F50CEB92679E3C4008A38BA /* ServerAPIv3Handler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAPIv3Handler.swift; sourceTree = "<group>"; };
 		6F54C92C25E033EE00A42C8F /* AddServerViewController+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddServerViewController+macOS.swift"; sourceTree = "<group>"; };
 		6F54C93725E0359200A42C8F /* AddServerViewController+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddServerViewController+iOS.swift"; sourceTree = "<group>"; };
 		6F54C9E625E2D6A500A42C8F /* MainViewController+StatusItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MainViewController+StatusItem.swift"; sourceTree = "<group>"; };
@@ -1146,6 +1149,7 @@
 				6FADF82624ADF2E600B75E8D /* ServerInfoFetcher.swift */,
 				C7DB4C062480570D009932B1 /* Moya */,
 				6FF8A351267742AA00E1C22C /* ServerAPIv2Handler.swift */,
+				6F50CEB92679E3C4008A38BA /* ServerAPIv3Handler.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -2106,6 +2110,7 @@
 				C7DB4B9F247FC23D009932B1 /* ConnectionViewController.swift in Sources */,
 				6F9CE541261802F10065E4BA /* CredentialsViewController+macOS.swift in Sources */,
 				6FE5668D259089800008D0D3 /* OpenVPNConfigImportHelper.swift in Sources */,
+				6F50CEBA2679E3C4008A38BA /* ServerAPIv3Handler.swift in Sources */,
 				6F36A79B24B6ED5D00BA8F5E /* SearchViewController+macOS.swift in Sources */,
 				6FADF82D24ADF6C600B75E8D /* ConnectableInstance.swift in Sources */,
 				C7DB4BCF24803A2A009932B1 /* ServerInfo.swift in Sources */,
@@ -2193,6 +2198,7 @@
 				6F5E6C352522E8A0000225C0 /* Log.swift in Sources */,
 				6F5E6C432522E9BF000225C0 /* ServerDiscoveryService.swift in Sources */,
 				C7DB4C36248060F5009932B1 /* FileHelper.swift in Sources */,
+				6F50CEBB2679E3C4008A38BA /* ServerAPIv3Handler.swift in Sources */,
 				6F116CB225345D3B00C73797 /* ConnectionAttempt.swift in Sources */,
 				6F5E6C3C2522E935000225C0 /* ConnectableInstance.swift in Sources */,
 				C7DB4C37248060F5009932B1 /* Multiplatform.swift in Sources */,

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		6FEF313524A4908F0026C786 /* Common.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FEF313324A48FB10026C786 /* Common.xcassets */; };
 		6FEF313B24A717570026C786 /* ServerAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEF313A24A717570026C786 /* ServerAuthService.swift */; };
 		6FEF313D24A746AD0026C786 /* AuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEF313C24A746AD0026C786 /* AuthState.swift */; };
+		6FF8A352267742AA00E1C22C /* ServerAPIv2Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF8A351267742AA00E1C22C /* ServerAPIv2Handler.swift */; };
+		6FF8A353267742AA00E1C22C /* ServerAPIv2Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF8A351267742AA00E1C22C /* ServerAPIv2Handler.swift */; };
 		6FFC4065266E392000835B43 /* TunnelConfiguration+WgQuickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFC4064266E392000835B43 /* TunnelConfiguration+WgQuickConfig.swift */; };
 		6FFC4066266E392000835B43 /* TunnelConfiguration+WgQuickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFC4064266E392000835B43 /* TunnelConfiguration+WgQuickConfig.swift */; };
 		6FFC4089266F51D200835B43 /* String+ArrayConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFC4088266F51D200835B43 /* String+ArrayConversion.swift */; };
@@ -449,6 +451,7 @@
 		6FEF313324A48FB10026C786 /* Common.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Common.xcassets; sourceTree = "<group>"; };
 		6FEF313A24A717570026C786 /* ServerAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAuthService.swift; sourceTree = "<group>"; };
 		6FEF313C24A746AD0026C786 /* AuthState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthState.swift; sourceTree = "<group>"; };
+		6FF8A351267742AA00E1C22C /* ServerAPIv2Handler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAPIv2Handler.swift; sourceTree = "<group>"; };
 		6FFC4064266E392000835B43 /* TunnelConfiguration+WgQuickConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TunnelConfiguration+WgQuickConfig.swift"; sourceTree = "<group>"; };
 		6FFC4088266F51D200835B43 /* String+ArrayConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+ArrayConversion.swift"; sourceTree = "<group>"; };
 		6FFD421C254977240093533C /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
@@ -1142,6 +1145,7 @@
 				6F71FBBC249CCE980010D0FE /* DiscoveryDataFetcher.swift */,
 				6FADF82624ADF2E600B75E8D /* ServerInfoFetcher.swift */,
 				C7DB4C062480570D009932B1 /* Moya */,
+				6FF8A351267742AA00E1C22C /* ServerAPIv2Handler.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -2093,6 +2097,7 @@
 				6FEF313B24A717570026C786 /* ServerAuthService.swift in Sources */,
 				6F4C1ED625D12D710042AD95 /* SharedTunnelOptions.swift in Sources */,
 				6F8AEE7925E6D508001A603B /* StatusItemConnectionInfoHelper.swift in Sources */,
+				6FF8A352267742AA00E1C22C /* ServerAPIv2Handler.swift in Sources */,
 				6F50408D254C33C50071AA66 /* ConnectionViewModel+SupportContact.swift in Sources */,
 				6F42B1A624E333A800800FAC /* (null) in Sources */,
 				6FEF313D24A746AD0026C786 /* AuthState.swift in Sources */,
@@ -2183,6 +2188,7 @@
 				6F5E6C3E2522E93D000225C0 /* ServerResponse.swift in Sources */,
 				6F5E6C322522E72F000225C0 /* SectionHeaderCell.swift in Sources */,
 				C7DB4C34248060F5009932B1 /* Config.swift in Sources */,
+				6FF8A353267742AA00E1C22C /* ServerAPIv2Handler.swift in Sources */,
 				6F85D3C125F7FD3B00E8B513 /* NotificationService.swift in Sources */,
 				6F5E6C352522E8A0000225C0 /* Log.swift in Sources */,
 				6F5E6C432522E9BF000225C0 /* ServerDiscoveryService.swift in Sources */,

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -3407,8 +3407,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://git.zx2c4.com/wireguard-apple/";
 			requirement = {
-				kind = exactVersion;
-				version = "1.0.12-22";
+				kind = revision;
+				revision = 13b720442d47b67a18d6841aa34569633a22b458;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -77,7 +77,7 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
     private var viewModel: ConnectionViewModel!
     private var dataStore: PersistenceService.DataStore!
 
-    private var profiles: [ProfileListResponse.Profile]?
+    private var profiles: [Profile]?
     private var selectedProfileId: String? {
         didSet {
             if let server = parameters.connectableInstance as? ServerInstance {
@@ -534,7 +534,7 @@ private extension ConnectionViewController {
 extension ConnectionViewController: ConnectionViewModelDelegate {
 
     func connectionViewModel(
-        _ model: ConnectionViewModel, foundProfiles profiles: [ProfileListResponse.Profile]) {
+        _ model: ConnectionViewModel, foundProfiles profiles: [Profile]) {
         self.profiles = profiles
         if let selectedProfileId = selectedProfileId {
             if !profiles.contains(where: { $0.profileId == selectedProfileId }) {

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -484,8 +484,8 @@ private extension ConnectionViewController {
     #endif
 
     private func showAlert(for error: Error) {
-        if let serverAPIError = error as? ServerAPIServiceError,
-            case ServerAPIServiceError.errorGettingProfileConfig = serverAPIError {
+        if let serverAPIError = error as? ServerAPIv2Error,
+            case ServerAPIv2Error.errorGettingProfileConfig = serverAPIError {
 
             // If there's an error getting profile config, offer to refresh profiles
 

--- a/EduVPN/Helpers/CertificateExpiryHelper.swift
+++ b/EduVPN/Helpers/CertificateExpiryHelper.swift
@@ -159,7 +159,7 @@ extension CertificateExpiryHelper.CertificateStatus {
         case .validFor(let timeRemaining):
             // Show renewal button if session expires in
             // less than a week.
-            return timeRemaining < (60 * 24 * 7)
+            return timeRemaining < (60 * 60 * 24 * 7)
         case .expired:
             return true
         }

--- a/EduVPN/Helpers/CertificateExpiryHelper.swift
+++ b/EduVPN/Helpers/CertificateExpiryHelper.swift
@@ -8,11 +8,10 @@ import Foundation
 class CertificateExpiryHelper {
 
     enum CertificateStatus: Equatable {
-        case validFor(timeInterval: TimeInterval, proportionRemaining: Double)
+        case validFor(timeInterval: TimeInterval)
         case expired
     }
 
-    let validFrom: Date
     let expiresAt: Date
 
     private let handler: (CertificateStatus) -> Void
@@ -25,11 +24,10 @@ class CertificateExpiryHelper {
         }
     }
 
-    init(validFrom: Date, expiresAt: Date, handler: @escaping (CertificateStatus) -> Void) {
-        self.validFrom = validFrom
+    init(expiresAt: Date, handler: @escaping (CertificateStatus) -> Void) {
         self.expiresAt = expiresAt
         self.handler = handler
-        self.refreshTimes = Self.computeRefreshTimes(from: Date(), to: expiresAt, validFrom: validFrom)
+        self.refreshTimes = Self.computeRefreshTimes(from: Date(), to: expiresAt)
         self.scheduleNextRefresh()
     }
 
@@ -51,8 +49,7 @@ private extension CertificateExpiryHelper {
         static let tillWhichToShowMinutesSeconds: Int = 0
     }
 
-    static func computeRefreshTimes(from startDate: Date, to endDate: Date, validFrom: Date) -> [(refreshAt: Date, state: CertificateStatus)] {
-        let validityPeriod = endDate.timeIntervalSince(validFrom)
+    static func computeRefreshTimes(from startDate: Date, to endDate: Date) -> [(refreshAt: Date, state: CertificateStatus)] {
         let endingTimeInterval = endDate.timeIntervalSince(startDate)
 
         var refreshTimes: [(refreshAt: Date, state: CertificateStatus)] = []
@@ -60,10 +57,9 @@ private extension CertificateExpiryHelper {
 
         while currentTimeInterval < endingTimeInterval {
             let timeRemaining = endingTimeInterval - currentTimeInterval
-            let proportionRemaining = (timeRemaining / validityPeriod)
             refreshTimes.append(
                 (refreshAt: Date(timeInterval: currentTimeInterval, since: startDate),
-                 state: .validFor(timeInterval: timeRemaining, proportionRemaining: proportionRemaining)))
+                 state: .validFor(timeInterval: timeRemaining)))
 
             let secondsRemaining = Int(endingTimeInterval - currentTimeInterval)
             if secondsRemaining > NumberOfSeconds.tillWhichToShowDaysHours {
@@ -133,7 +129,7 @@ extension CertificateExpiryHelper.CertificateStatus {
 
     var localizedText: String {
         switch self {
-        case .validFor(let timeInterval, _):
+        case .validFor(let timeInterval):
             let localizedTimeLeftString: String?
             if timeInterval > TimeInterval(CertificateExpiryHelper.NumberOfSeconds.tillWhichToShowDaysHours) {
                 localizedTimeLeftString = Self.daysHoursFormatter.string(from: timeInterval)
@@ -160,8 +156,10 @@ extension CertificateExpiryHelper.CertificateStatus {
 
     var shouldShowRenewSessionButton: Bool {
         switch self {
-        case .validFor(_, let proportionRemaining):
-            return proportionRemaining < 0.2
+        case .validFor(let timeRemaining):
+            // Show renewal button if session expires in
+            // less than a week.
+            return timeRemaining < (60 * 24 * 7)
         case .expired:
             return true
         }

--- a/EduVPN/Helpers/Testing.swift
+++ b/EduVPN/Helpers/Testing.swift
@@ -2,8 +2,7 @@
 //  Testing.swift
 //  EduVPN
 //
-//  Created by Johan Kool on 11/12/2020.
-//  Copyright © 2020 SURFNet. All rights reserved.
+//  Copyright © 2020-2021 The Commons Conservancy. All rights reserved.
 //
 
 import Foundation

--- a/EduVPN/Models/ConnectionAttempt.swift
+++ b/EduVPN/Models/ConnectionAttempt.swift
@@ -20,8 +20,7 @@ struct ConnectionAttempt {
         // The state before connection was attempted to a ServerInstance
         let profiles: [Profile]
         let selectedProfileId: String
-        let certificateValidFrom: Date
-        let certificateExpiresAt: Date
+        let sessionExpiresAt: Date
     }
 
     struct VPNConfigPreConnectionState {
@@ -53,14 +52,13 @@ struct ConnectionAttempt {
 
     init(server: ServerInstance, profiles: [Profile],
          selectedProfileId: String,
-         certificateValidityRange: ServerAPIService.CertificateValidityRange,
+         sessionExpiresAt: Date,
          attemptId: UUID) {
         self.connectableInstance = server
         self.preConnectionState = .serverState(
             ServerPreConnectionState(
                 profiles: profiles, selectedProfileId: selectedProfileId,
-                certificateValidFrom: certificateValidityRange.validFrom,
-                certificateExpiresAt: certificateValidityRange.expiresAt))
+                sessionExpiresAt: sessionExpiresAt))
         self.attemptId = attemptId
     }
 
@@ -77,8 +75,7 @@ extension ConnectionAttempt.ServerPreConnectionState: Codable {
     enum CodingKeys: String, CodingKey {
         case profiles
         case selectedProfileId = "selected_profile_id"
-        case certificateValidFrom = "certificate_valid_from"
-        case certificateExpiresAt = "certificate_expires_at"
+        case sessionExpiresAt = "session_expires_at"
     }
 }
 

--- a/EduVPN/Models/ConnectionAttempt.swift
+++ b/EduVPN/Models/ConnectionAttempt.swift
@@ -18,7 +18,7 @@ enum ConnectionAttemptDecodingError: Error {
 struct ConnectionAttempt {
     struct ServerPreConnectionState {
         // The state before connection was attempted to a ServerInstance
-        let profiles: [ProfileListResponse.Profile]
+        let profiles: [Profile]
         let selectedProfileId: String
         let certificateValidFrom: Date
         let certificateExpiresAt: Date
@@ -51,7 +51,7 @@ struct ConnectionAttempt {
     let preConnectionState: PreConnectionState
     let attemptId: UUID
 
-    init(server: ServerInstance, profiles: [ProfileListResponse.Profile],
+    init(server: ServerInstance, profiles: [Profile],
          selectedProfileId: String,
          certificateValidityRange: ServerAPIService.CertificateValidityRange,
          attemptId: UUID) {

--- a/EduVPN/Models/ConnectionAttempt.swift
+++ b/EduVPN/Models/ConnectionAttempt.swift
@@ -21,6 +21,8 @@ struct ConnectionAttempt {
         let profiles: [Profile]
         let selectedProfileId: String
         let sessionExpiresAt: Date
+        let serverAPIBaseURL: URL
+        let serverAPIVersion: ServerInfo.APIVersion
     }
 
     struct VPNConfigPreConnectionState {
@@ -53,12 +55,17 @@ struct ConnectionAttempt {
     init(server: ServerInstance, profiles: [Profile],
          selectedProfileId: String,
          sessionExpiresAt: Date,
+         serverAPIBaseURL: URL,
+         serverAPIVersion: ServerInfo.APIVersion,
          attemptId: UUID) {
         self.connectableInstance = server
         self.preConnectionState = .serverState(
             ServerPreConnectionState(
-                profiles: profiles, selectedProfileId: selectedProfileId,
-                sessionExpiresAt: sessionExpiresAt))
+                profiles: profiles,
+                selectedProfileId: selectedProfileId,
+                sessionExpiresAt: sessionExpiresAt,
+                serverAPIBaseURL: serverAPIBaseURL,
+                serverAPIVersion: serverAPIVersion))
         self.attemptId = attemptId
     }
 
@@ -76,6 +83,8 @@ extension ConnectionAttempt.ServerPreConnectionState: Codable {
         case profiles
         case selectedProfileId = "selected_profile_id"
         case sessionExpiresAt = "session_expires_at"
+        case serverAPIBaseURL = "api_base_url"
+        case serverAPIVersion = "api_version"
     }
 }
 

--- a/EduVPN/Models/ServerInfo.swift
+++ b/EduVPN/Models/ServerInfo.swift
@@ -12,6 +12,12 @@ struct ServerInfo: Decodable {
     typealias BaseURL = URL
     typealias OAuthEndpoint = URL
 
+    enum APIVersion {
+        case apiv2
+        case apiv3
+    }
+
+    var apiVersion: APIVersion
     var authorizationEndpoint: OAuthEndpoint
     var tokenEndpoint: OAuthEndpoint
     var apiBaseURL: BaseURL
@@ -21,22 +27,39 @@ extension ServerInfo {
 
     enum ServerInfoKeys: String, CodingKey {
         case api
-        case apiInfo = "http://eduvpn.org/api#2"
+        case apiv2 = "http://eduvpn.org/api#2"
+        case apiv3 = "http://eduvpn.org/api#3"
         case authorizationEndpoint = "authorization_endpoint"
         case tokenEndpoint = "token_endpoint"
-        case apiBaseURL = "api_base_uri"
+        case apiBaseURL = "api_base_uri" // Only in APIv2
+        case apiEndpoint = "api_endpoint" // Only in APIv3
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: ServerInfoKeys.self)
-        
         let apiContainer = try container.nestedContainer(keyedBy: ServerInfoKeys.self, forKey: .api)
-        let apiInfoContainer = try apiContainer.nestedContainer(keyedBy: ServerInfoKeys.self, forKey: .apiInfo)
-        
-        let authorizationEndpoint = try apiInfoContainer.decode(URL.self, forKey: .authorizationEndpoint)
-        let tokenEndpoint = try apiInfoContainer.decode(URL.self, forKey: .tokenEndpoint)
-        let apiBaseURL = try apiInfoContainer.decode(URL.self, forKey: .apiBaseURL)
-        
-        self.init(authorizationEndpoint: authorizationEndpoint, tokenEndpoint: tokenEndpoint, apiBaseURL: apiBaseURL)
+
+        if let apiv3Container = try? apiContainer.nestedContainer(keyedBy: ServerInfoKeys.self, forKey: .apiv3) {
+            let authorizationEndpoint = try apiv3Container.decode(URL.self, forKey: .authorizationEndpoint)
+            let tokenEndpoint = try apiv3Container.decode(URL.self, forKey: .tokenEndpoint)
+            let apiBaseURL = try apiv3Container.decode(URL.self, forKey: .apiEndpoint)
+
+            self.init(
+                apiVersion: .apiv3,
+                authorizationEndpoint: authorizationEndpoint,
+                tokenEndpoint: tokenEndpoint,
+                apiBaseURL: apiBaseURL)
+        } else {
+            let apiv2Container = try apiContainer.nestedContainer(keyedBy: ServerInfoKeys.self, forKey: .apiv2)
+            let authorizationEndpoint = try apiv2Container.decode(URL.self, forKey: .authorizationEndpoint)
+            let tokenEndpoint = try apiv2Container.decode(URL.self, forKey: .tokenEndpoint)
+            let apiBaseURL = try apiv2Container.decode(URL.self, forKey: .apiBaseURL)
+
+            self.init(
+                apiVersion: .apiv2,
+                authorizationEndpoint: authorizationEndpoint,
+                tokenEndpoint: tokenEndpoint,
+                apiBaseURL: apiBaseURL)
+        }
     }
 }

--- a/EduVPN/Models/ServerInfo.swift
+++ b/EduVPN/Models/ServerInfo.swift
@@ -12,9 +12,9 @@ struct ServerInfo: Decodable {
     typealias BaseURL = URL
     typealias OAuthEndpoint = URL
 
-    enum APIVersion: String {
-        case apiv2
-        case apiv3
+    enum APIVersion: String, Codable {
+        case apiv2 = "http://eduvpn.org/api#2"
+        case apiv3 = "http://eduvpn.org/api#3"
     }
 
     var apiVersion: APIVersion

--- a/EduVPN/Models/ServerInfo.swift
+++ b/EduVPN/Models/ServerInfo.swift
@@ -12,7 +12,7 @@ struct ServerInfo: Decodable {
     typealias BaseURL = URL
     typealias OAuthEndpoint = URL
 
-    enum APIVersion {
+    enum APIVersion: String {
         case apiv2
         case apiv3
     }

--- a/EduVPN/Models/ServerResponse.swift
+++ b/EduVPN/Models/ServerResponse.swift
@@ -124,7 +124,7 @@ struct ProfileConfigResponse: ServerResponseAPIv2 {
 //     }
 // }
 
-struct ProfileConfigErrorResponse: Decodable {
+struct ProfileConfigErrorResponsev2: Decodable {
 
     let errorMessage: String
 
@@ -240,5 +240,26 @@ struct ConnectResponse: ServerResponseAPIv3 {
     let data: Data
     init(data: Data) {
         self.data = data
+    }
+}
+
+// Parse error response to a /connect request
+//
+// Example error response:
+// {
+//     "error": "invalid \"profile_id\""
+// }
+
+struct ProfileConfigErrorResponse: Decodable {
+
+    let errorMessage: String
+
+    enum TopLevelKeys: String, CodingKey {
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let topLevelContainer = try decoder.container(keyedBy: TopLevelKeys.self)
+        self.errorMessage = try topLevelContainer.decode(String.self, forKey: .error)
     }
 }

--- a/EduVPN/Models/ServerResponse.swift
+++ b/EduVPN/Models/ServerResponse.swift
@@ -184,3 +184,61 @@ private enum SecondLevelKeys: String, CodingKey {
     case data
     case error
 }
+
+// Responses for APIv3
+
+protocol ServerResponseAPIv3: ServerResponse {
+}
+
+// Parse response to a /info request
+//
+// Example response:
+// {
+//     "info": {
+//         "profile_list": [
+//             {
+//                 "display_name": {
+//                     "en": "Employees",
+//                     "nl": "Medewerkers"
+//                 },
+//                 "profile_id": "employees"
+//             },
+//             {
+//                 "display_name": "Administrators",
+//                 "profile_id": "admins"
+//             }
+//         ]
+//     }
+// }
+
+struct InfoResponse: ServerResponseAPIv3, Decodable {
+    let data: [Profile]
+
+    enum TopLevelKeys: String, CodingKey {
+        case info
+    }
+
+    enum SecondLevelKeys: String, CodingKey {
+        case profile_list // swiftlint:disable:this identifier_name
+    }
+
+    init(from decoder: Decoder) throws {
+        let topLevelContainer = try decoder.container(keyedBy: TopLevelKeys.self)
+        let profileListContainer = try topLevelContainer.nestedContainer(
+            keyedBy: SecondLevelKeys.self, forKey: .info)
+        self.data = try profileListContainer.decode([Profile].self, forKey: .profile_list)
+    }
+
+    init(data: Data) throws {
+        self = try JSONDecoder().decode(InfoResponse.self, from: data)
+    }
+}
+
+// The response to a /connect request is raw data
+
+struct ConnectResponse: ServerResponseAPIv3 {
+    let data: Data
+    init(data: Data) {
+        self.data = data
+    }
+}

--- a/EduVPN/Models/ServerResponse.swift
+++ b/EduVPN/Models/ServerResponse.swift
@@ -42,7 +42,7 @@ protocol ServerResponseAPIv2: ServerResponse {
 //     }
 // }
 
-struct ProfileListResponse: ServerResponseAPIv2, Decodable {
+struct ProfileListResponsev2: ServerResponseAPIv2, Decodable {
     let data: [Profile]
 
     enum TopLevelKeys: String, CodingKey {
@@ -57,7 +57,7 @@ struct ProfileListResponse: ServerResponseAPIv2, Decodable {
     }
 
     init(data: Data) throws {
-        self = try JSONDecoder().decode(ProfileListResponse.self, from: data)
+        self = try JSONDecoder().decode(ProfileListResponsev2.self, from: data)
     }
 }
 

--- a/EduVPN/Models/ServerResponse.swift
+++ b/EduVPN/Models/ServerResponse.swift
@@ -11,6 +11,16 @@ protocol ServerResponse {
     init(data: Data) throws
 }
 
+struct Profile: Codable {
+    let displayName: LanguageMappedString
+    let profileId: String
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "display_name"
+        case profileId = "profile_id"
+    }
+}
+
 // Parse response to a /profile_list request
 //
 // Example response:
@@ -28,17 +38,6 @@ protocol ServerResponse {
 // }
 
 struct ProfileListResponse: ServerResponse, Decodable {
-    struct Profile: Codable {
-        let displayName: LanguageMappedString
-        let profileId: String
-
-        // swiftlint:disable:next nesting
-        enum CodingKeys: String, CodingKey {
-            case displayName = "display_name"
-            case profileId = "profile_id"
-        }
-    }
-
     let data: [Profile]
 
     enum TopLevelKeys: String, CodingKey {

--- a/EduVPN/Models/ServerResponse.swift
+++ b/EduVPN/Models/ServerResponse.swift
@@ -21,6 +21,11 @@ struct Profile: Codable {
     }
 }
 
+// Responses for APIv2
+
+protocol ServerResponseAPIv2: ServerResponse {
+}
+
 // Parse response to a /profile_list request
 //
 // Example response:
@@ -37,7 +42,7 @@ struct Profile: Codable {
 //     }
 // }
 
-struct ProfileListResponse: ServerResponse, Decodable {
+struct ProfileListResponse: ServerResponseAPIv2, Decodable {
     let data: [Profile]
 
     enum TopLevelKeys: String, CodingKey {
@@ -69,7 +74,7 @@ struct ProfileListResponse: ServerResponse, Decodable {
 //     }
 // }
 
-struct CreateKeyPairResponse: ServerResponse, Decodable {
+struct CreateKeyPairResponse: ServerResponseAPIv2, Decodable {
 
     struct KeyPair: Codable {
         let certificate: String
@@ -102,7 +107,7 @@ struct CreateKeyPairResponse: ServerResponse, Decodable {
 
 // The response to a /profile_config request is raw data
 
-struct ProfileConfigResponse: ServerResponse {
+struct ProfileConfigResponse: ServerResponseAPIv2 {
     let data: Data
     init(data: Data) {
         self.data = data
@@ -147,7 +152,7 @@ struct ProfileConfigErrorResponse: Decodable {
 //     }
 // }
 
-struct CheckCertificateResponse: ServerResponse, Decodable {
+struct CheckCertificateResponse: ServerResponseAPIv2, Decodable {
     struct CertificateValidity: Decodable {
         let isValid: Bool
 

--- a/EduVPN/Networking/ServerAPIv2Handler.swift
+++ b/EduVPN/Networking/ServerAPIv2Handler.swift
@@ -100,6 +100,12 @@ struct ServerAPIv2Handler: ServerAPIHandler {
             }
         }
     }
+
+    static func attemptToRelinquishTunnelConfiguration(
+        baseURL: URL, dataStore: PersistenceService.DataStore, session: Moya.Session,
+        profile: Profile) {
+        // Nothing to do
+    }
 }
 
 private extension ServerAPIv2Handler {

--- a/EduVPN/Networking/ServerAPIv2Handler.swift
+++ b/EduVPN/Networking/ServerAPIv2Handler.swift
@@ -1,0 +1,334 @@
+//
+//  ServerAPIv2Handler.swift
+//  EduVPN
+//
+//  Copyright © 2021 SURFNet. All rights reserved.
+
+import Foundation
+import AppAuth
+import Moya
+import PromiseKit
+import ASN1Decoder
+import os.log
+
+enum ServerAPIv2Error: Error {
+    case serverProvidedInvalidCertificate
+    case HTTPFailure(requestURLPath: String, response: Moya.Response)
+    case errorGettingProfileConfig(profile: Profile, serverError: String)
+    case openVPNConfigHasInvalidEncoding
+    case openVPNConfigHasNoCertificateAuthority
+    case openVPNConfigHasNoRemotes
+    case openVPNConfigHasOnlyUDPRemotes // and UDP is not allowed
+}
+
+extension ServerAPIv2Error: AppError {
+    var summary: String {
+        switch self {
+        case .serverProvidedInvalidCertificate:
+            return "Server provided invalid certificate"
+        case .HTTPFailure:
+            return "HTTP request failed"
+        case .errorGettingProfileConfig:
+            return "Error getting profile config"
+        case .openVPNConfigHasInvalidEncoding:
+            return "OpenVPN config has unrecognized encoding"
+        case .openVPNConfigHasNoCertificateAuthority:
+            return "OpenVPN config has no certificate authority"
+        case .openVPNConfigHasNoRemotes:
+            return "OpenVPN config has no remotes"
+        case .openVPNConfigHasOnlyUDPRemotes:
+            return "OpenVPN config has no TCP remotes, but only TCP can be used as per preferences"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .serverProvidedInvalidCertificate:
+            return "Server provided invalid certificate"
+        case .HTTPFailure(let requestURLPath, let response):
+            return """
+            Request path: \(requestURLPath)
+            Response code: \(response.statusCode)
+            Response: \(String(data: response.data, encoding: .utf8) ?? "")
+            """
+        case .errorGettingProfileConfig(let profile, let serverError):
+            return """
+            Requested profile: \(profile.displayName.stringForCurrentLanguage())
+            Server error: \(serverError)
+            """
+        default:
+            return ""
+        }
+    }
+}
+
+struct ServerAPIv2Handler: ServerAPIHandler {
+    static var authStateChangeHandler: AuthStateChangeHandler?
+
+    static func getAvailableProfiles(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        options: ServerAPIService.Options) -> Promise<[Profile]> {
+
+        return Self.makeRequest(target: .profileList(commonInfo),
+                           decodeAs: ProfileListResponsev2.self,
+                           options: options)
+    }
+
+    static func getTunnelConfigurationData(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        profile: Profile,
+        options: ServerAPIService.Options) -> Promise<ServerAPIService.TunnelConfigurationData> {
+
+        firstly { () -> Promise<KeyPairData> in
+            return Self.getKeyPair(commonInfo: commonInfo, options: options)
+        }.then { keyPairData -> Promise<ServerAPIService.TunnelConfigurationData> in
+            // Can reuse the auth state we just got from getKeyPair
+            let updatedOptions = options.subtracting([.ignoreStoredAuthState])
+            return firstly {
+                Self.getProfileConfig(commonInfo: commonInfo,
+                                      profile: profile,
+                                      options: updatedOptions)
+            }.map { profileConfig in
+                let isUDPAllowed = !UserDefaults.standard.forceTCP
+                let openVPNConfig = try Self.createOpenVPNConfig(
+                    profileConfig: profileConfig, isUDPAllowed: isUDPAllowed, keyPair: keyPairData.keyPair)
+                return ServerAPIService.TunnelConfigurationData(
+                    vpnConfig: .openVPNConfig(openVPNConfig),
+                    expiresAt: keyPairData.certificateExpiryDate)
+            }
+        }
+    }
+}
+
+private extension ServerAPIv2Handler {
+
+    enum ServerAPITarget: TargetType, AcceptJson, AccessTokenAuthorizable {
+        case profileList(ServerAPIService.CommonAPIRequestInfo)
+        case createKeyPair(ServerAPIService.CommonAPIRequestInfo, displayName: String)
+        case checkCertificate(ServerAPIService.CommonAPIRequestInfo, commonName: String)
+        case profileConfig(ServerAPIService.CommonAPIRequestInfo, profile: Profile)
+
+        var commonInfo: ServerAPIService.CommonAPIRequestInfo {
+            switch self {
+            case .profileList(let commonInfo): return commonInfo
+            case .createKeyPair(let commonInfo, _): return commonInfo
+            case .checkCertificate(let commonInfo, _): return commonInfo
+            case .profileConfig(let commonInfo, _): return commonInfo
+            }
+        }
+
+        var baseURL: URL { commonInfo.serverInfo.apiBaseURL }
+
+        var path: String {
+            switch self {
+            case .profileList: return "/profile_list"
+            case .createKeyPair: return "/create_keypair"
+            case .checkCertificate: return "/check_certificate"
+            case .profileConfig: return "/profile_config"
+            }
+        }
+
+        var method: Moya.Method {
+            switch self {
+            case .profileList, .checkCertificate, .profileConfig: return .get
+            case .createKeyPair: return .post
+            }
+        }
+
+        var sampleData: Data { Data() }
+
+        var task: Task {
+            switch self {
+            case .profileList:
+                return .requestPlain
+            case .createKeyPair(_, let displayName):
+                return .requestParameters(
+                    parameters: ["display_name": displayName],
+                    encoding: URLEncoding.httpBody)
+            case .checkCertificate(_, let commonName):
+                return .requestParameters(
+                    parameters: ["common_name": commonName],
+                    encoding: URLEncoding.queryString)
+            case .profileConfig(_, let profile):
+                return .requestParameters(
+                    parameters: ["profile_id": profile.profileId],
+                    encoding: URLEncoding.queryString)
+            }
+        }
+
+        var authorizationType: AuthorizationType? { .bearer }
+    }
+
+    static let HTTPStatusCodeUnauthorized = 401
+
+    struct KeyPairData {
+        let keyPair: CreateKeyPairResponse.KeyPair
+        let certificateExpiryDate: Date
+    }
+
+    static func makeRequest<T: ServerResponse>(
+        target: ServerAPITarget,
+        decodeAs responseType: T.Type,
+        options: ServerAPIService.Options) -> Promise<T.DataType> {
+
+        firstly { () -> Promise<String> in
+            Self.getFreshAccessToken(
+                commonInfo: target.commonInfo,
+                options: options)
+        }.then { accessToken -> Promise<Moya.Response> in
+            let authPlugin = AccessTokenPlugin { _ in accessToken }
+            let provider = MoyaProvider<ServerAPITarget>(session: target.commonInfo.session, plugins: [authPlugin])
+            return provider.request(target: target)
+        }.then { response -> Promise<T.DataType> in
+            if response.statusCode == Self.HTTPStatusCodeUnauthorized &&
+                !options.contains(.ignoreStoredAuthState) {
+                os_log("Encountered HTTP status code Unauthorized", log: Log.general, type: .info)
+                return Self.makeRequest(
+                    target: target,
+                    decodeAs: responseType,
+                    options: options.union([.ignoreStoredAuthState]))
+            } else {
+                let successStatusCodes = (200...299)
+                guard successStatusCodes.contains(response.statusCode) else {
+                    throw ServerAPIv2Error.HTTPFailure(requestURLPath: target.path, response: response)
+                }
+                return Promise.value(try T(data: response.data).data)
+            }
+        }
+    }
+
+    static func getKeyPair(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        options: ServerAPIService.Options) -> Promise<KeyPairData> {
+
+        firstly { () -> Promise<KeyPairData> in
+            guard !options.contains(.ignoreStoredKeyPair),
+                let storedKeyPair = commonInfo.dataStore.keyPair,
+                let certificateData = storedKeyPair.certificate.data(using: .utf8),
+                let x509Certificate = try? X509Certificate(data: certificateData),
+                x509Certificate.isCurrentlyValid,
+                let commonName = x509Certificate.commonName,
+                let expiresAt = x509Certificate.expiresAt else {
+                throw ServerAPIServiceError.cannotUseStoredKeyPair
+            }
+            return makeRequest(
+                target: .checkCertificate(commonInfo, commonName: commonName),
+                decodeAs: CheckCertificateResponse.self, options: options)
+                .map { certificateValidity in
+                    guard certificateValidity.isValid else {
+                        throw ServerAPIServiceError.cannotUseStoredKeyPair
+                    }
+                    return KeyPairData(keyPair: storedKeyPair, certificateExpiryDate: expiresAt)
+                }
+        }.recover { error -> Promise<KeyPairData> in
+            if case ServerAPIServiceError.cannotUseStoredKeyPair = error {
+                return Self.makeRequest(
+                    target: .createKeyPair(commonInfo, displayName: Config.shared.appName),
+                    decodeAs: CreateKeyPairResponse.self, options: options)
+                    .map { keyPair in
+                        commonInfo.dataStore.keyPair = keyPair
+                        guard let certificateData = keyPair.certificate.data(using: .utf8),
+                            let x509Certificate = try? X509Certificate(data: certificateData),
+                            x509Certificate.isCurrentlyValid,
+                            let expiresAt = x509Certificate.expiresAt else {
+                                throw ServerAPIv2Error.serverProvidedInvalidCertificate
+                        }
+                        return KeyPairData(keyPair: keyPair, certificateExpiryDate: expiresAt)
+                    }
+            } else {
+                throw error
+            }
+        }
+    }
+
+    static func getProfileConfig(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        profile: Profile,
+        options: ServerAPIService.Options) -> Promise<Data> {
+
+        firstly {
+            makeRequest(target: .profileConfig(commonInfo, profile: profile),
+                        decodeAs: ProfileConfigResponse.self, options: options)
+        }.map { data in
+            if let errorResponse = try? JSONDecoder().decode(ProfileConfigErrorResponse.self, from: data) {
+                throw ServerAPIv2Error.errorGettingProfileConfig(profile: profile, serverError: errorResponse.errorMessage)
+            }
+            return data
+        }
+    }
+
+    static func createOpenVPNConfig(
+        profileConfig profileConfigData: Data,
+        isUDPAllowed: Bool,
+        keyPair: CreateKeyPairResponse.KeyPair) throws -> [String] {
+
+        guard let originalConfig = String(data: profileConfigData, encoding: .utf8) else {
+            throw ServerAPIv2Error.openVPNConfigHasInvalidEncoding
+        }
+
+        let originalConfigLines = originalConfig.components(separatedBy: .newlines)
+        let privateKeyLines = keyPair.privateKey.components(separatedBy: .newlines)
+        let certificateLines = keyPair.certificate.components(separatedBy: .newlines)
+
+        var hasCA = false
+        var hasRemote = false
+
+        var processedLines = [String]()
+        for originalLine in originalConfigLines {
+            let line = originalLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty { continue }
+            if line.hasSuffix("auth none") { continue }
+
+            if line.hasSuffix("</ca>") {
+                processedLines.append(line)
+                processedLines.append("<cert>")
+                processedLines.append(contentsOf: certificateLines)
+                processedLines.append("</cert>")
+                processedLines.append("<key>")
+                processedLines.append(contentsOf: privateKeyLines)
+                processedLines.append("</key>")
+                hasCA = true
+                continue
+            }
+
+            if line.hasPrefix("remote") {
+                let isUDPOnlyRemote = (line.hasSuffix(" udp") || line.hasSuffix(" udp4") || line.hasSuffix(" udp6"))
+                if !isUDPOnlyRemote || isUDPAllowed {
+                    processedLines.append(line)
+                    hasRemote = true
+                }
+                continue
+            }
+
+            processedLines.append(line)
+        }
+
+        guard hasCA else {
+            throw ServerAPIv2Error.openVPNConfigHasNoCertificateAuthority
+        }
+
+        guard hasRemote else {
+            throw ServerAPIv2Error.openVPNConfigHasNoRemotes
+        }
+
+        return processedLines
+    }
+}
+
+private extension X509Certificate {
+    var isCurrentlyValid: Bool {
+        return checkValidity()
+    }
+
+    var commonName: String? {
+        if let commonNameElements = subjectDistinguishedName?.split(separator: "=") {
+            if commonNameElements.count == 2 && commonNameElements[0] == "CN" {
+                return String(commonNameElements[1])
+            }
+        }
+        return nil
+    }
+
+    var validFrom: Date? { notBefore }
+    var expiresAt: Date? { notAfter }
+}

--- a/EduVPN/Networking/ServerAPIv2Handler.swift
+++ b/EduVPN/Networking/ServerAPIv2Handler.swift
@@ -2,7 +2,7 @@
 //  ServerAPIv2Handler.swift
 //  EduVPN
 //
-//  Copyright © 2021 SURFNet. All rights reserved.
+//  Copyright © 2020-2021 The Commons Conservancy. All rights reserved.
 
 import Foundation
 import AppAuth

--- a/EduVPN/Networking/ServerAPIv2Handler.swift
+++ b/EduVPN/Networking/ServerAPIv2Handler.swift
@@ -94,7 +94,9 @@ struct ServerAPIv2Handler: ServerAPIHandler {
                     profileConfig: profileConfig, isUDPAllowed: isUDPAllowed, keyPair: keyPairData.keyPair)
                 return ServerAPIService.TunnelConfigurationData(
                     vpnConfig: .openVPNConfig(openVPNConfig),
-                    expiresAt: keyPairData.certificateExpiryDate)
+                    expiresAt: keyPairData.certificateExpiryDate,
+                    serverAPIBaseURL: commonInfo.serverInfo.apiBaseURL,
+                    serverAPIVersion: commonInfo.serverInfo.apiVersion)
             }
         }
     }

--- a/EduVPN/Networking/ServerAPIv2Handler.swift
+++ b/EduVPN/Networking/ServerAPIv2Handler.swift
@@ -258,7 +258,7 @@ private extension ServerAPIv2Handler {
             makeRequest(target: .profileConfig(commonInfo, profile: profile),
                         decodeAs: ProfileConfigResponse.self, options: options)
         }.map { data in
-            if let errorResponse = try? JSONDecoder().decode(ProfileConfigErrorResponse.self, from: data) {
+            if let errorResponse = try? JSONDecoder().decode(ProfileConfigErrorResponsev2.self, from: data) {
                 throw ServerAPIv2Error.errorGettingProfileConfig(profile: profile, serverError: errorResponse.errorMessage)
             }
             return data

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -239,10 +239,20 @@ private extension ServerAPIv3Handler {
                 }
                 let data = try T(data: response.data).data
                 let httpResponse = response.response
+                let contentType: String?
+                let expires: String?
+                if #available(iOS 13.0, macOS 10.15, *) {
+                    contentType = httpResponse?.value(forHTTPHeaderField: "Content-Type")
+                    expires = httpResponse?.value(forHTTPHeaderField: "Expires")
+                } else {
+                    let allHeaders = httpResponse?.allHeaderFields
+                    contentType = allHeaders?["Content-Type"] as? String
+                    expires = allHeaders?["Expires"] as? String
+                }
                 let responseData = ResponseData<T>(
                     data: data,
-                    contentTypeResponseHeader: httpResponse?.value(forHTTPHeaderField: "Content-Type"),
-                    expiresResponseHeader: httpResponse?.value(forHTTPHeaderField: "Expires"))
+                    contentTypeResponseHeader: contentType,
+                    expiresResponseHeader: expires)
                 return Promise.value(responseData)
             }
         }

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -2,7 +2,7 @@
 //  ServerAPIv3Handler.swift
 //  EduVPN
 //
-//  Copyright © 2021 SURFNet. All rights reserved.
+//  Copyright © 2020-2021 The Commons Conservancy. All rights reserved.
 
 import Foundation
 import Moya

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -119,14 +119,18 @@ struct ServerAPIv3Handler: ServerAPIHandler {
                 let configLines = configString.split(separator: "\n").map { String($0) }
                 return ServerAPIService.TunnelConfigurationData(
                     vpnConfig: .openVPNConfig(configLines),
-                    expiresAt: expiresDate)
+                    expiresAt: expiresDate,
+                    serverAPIBaseURL: commonInfo.serverInfo.apiBaseURL,
+                    serverAPIVersion: commonInfo.serverInfo.apiVersion)
             case "application/x-wireguard-profile":
                 let updatedConfigString = try insertPrivateKey(privateKey, in: configString)
                 print("configString = \(configString)")
                 print("updatedConfigString = \(updatedConfigString)")
                 return ServerAPIService.TunnelConfigurationData(
                     vpnConfig: .wireGuardConfig(updatedConfigString),
-                    expiresAt: expiresDate)
+                    expiresAt: expiresDate,
+                    serverAPIBaseURL: commonInfo.serverInfo.apiBaseURL,
+                    serverAPIVersion: commonInfo.serverInfo.apiVersion)
             default:
                 throw ServerAPIv3Error.unexpectedContentTypeOnConnect(responseData.contentTypeResponseHeader)
             }

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -1,0 +1,254 @@
+//
+//  ServerAPIv3Handler.swift
+//  EduVPN
+//
+//  Copyright © 2021 SURFNet. All rights reserved.
+
+import Foundation
+import Moya
+import PromiseKit
+import WireGuardKit
+import os.log
+
+enum ServerAPIv3Error: Error {
+    case HTTPFailure(requestURLPath: String, response: Moya.Response)
+    case VPNConfigHasInvalidEncoding
+    case wgVPNConfigMissingInterfaceSection
+    case expiresResponseHeaderIsInvalid(String?)
+    case unexpectedContentTypeOnConnect(String?)
+}
+
+extension ServerAPIv3Error: AppError {
+    var summary: String {
+        switch self {
+        case .HTTPFailure:
+            return "HTTP request failed"
+        case .VPNConfigHasInvalidEncoding:
+            return "VPN config has unrecognized encoding"
+        case .wgVPNConfigMissingInterfaceSection:
+            return "WireGuard VPN config is missing its 'Interface' section"
+        case .expiresResponseHeaderIsInvalid:
+            return "Invalid expiration date value"
+        case .unexpectedContentTypeOnConnect:
+            return "Unexpected content type value"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .HTTPFailure(let requestURLPath, let response):
+            return """
+            Request path: \(requestURLPath)
+            Response code: \(response.statusCode)
+            Response: \(String(data: response.data, encoding: .utf8) ?? "")
+            """
+        case .expiresResponseHeaderIsInvalid(let value):
+            if let value = value {
+                return "The 'Expires' HTTP response header value returned was: \(value)"
+            } else {
+                return "No 'Expires' HTTP response header was returned"
+            }
+        case .unexpectedContentTypeOnConnect(let value):
+            if let value = value {
+                return "The 'Content-Type' HTTP response header value returned was: \(value)"
+            } else {
+                return "No 'Content-Type' HTTP response header was returned"
+            }
+        default:
+            return ""
+        }
+    }
+}
+
+struct ServerAPIv3Handler: ServerAPIHandler {
+    static var authStateChangeHandler: AuthStateChangeHandler?
+
+    static func getAvailableProfiles(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        options: ServerAPIService.Options) -> Promise<[Profile]> {
+
+        return Self.makeRequest(
+            target: .info(commonInfo),
+            decodeAs: InfoResponse.self,
+            options: options)
+            .map { $0.data }
+    }
+
+    // swiftlint:disable:next function_body_length
+    static func getTunnelConfigurationData(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        profile: Profile,
+        options: ServerAPIService.Options) -> Promise<ServerAPIService.TunnelConfigurationData> {
+
+        let privateKey: WireGuardKit.PrivateKey = {
+            // If a valid WireGuard private key is stored, return it.
+            // Else, create a new private key, store it, and return it.
+            guard let keyData = commonInfo.dataStore.wireGuardPrivateKey,
+                  let key = WireGuardKit.PrivateKey(rawValue: keyData) else {
+                let newKey = WireGuardKit.PrivateKey()
+                commonInfo.dataStore.wireGuardPrivateKey = newKey.rawValue
+                return newKey
+            }
+            return key
+        }()
+        let publicKey = privateKey.publicKey.base64Key
+
+        return firstly {
+            Self.makeRequest(
+                target: .connect(commonInfo, profile: profile, publicKey: publicKey),
+                decodeAs: ConnectResponse.self,
+                options: options)
+        }.map { responseData -> ServerAPIService.TunnelConfigurationData in
+            guard let configString = String(data: responseData.data, encoding: .utf8) else {
+                throw ServerAPIv3Error.VPNConfigHasInvalidEncoding
+            }
+            guard let expiresString = responseData.expiresResponseHeader else {
+                throw ServerAPIv3Error.expiresResponseHeaderIsInvalid(nil)
+            }
+
+            let dateFormatter = DateFormatter()
+            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+            dateFormatter.dateFormat = "EEE',' dd' 'MMM' 'yyyy HH':'mm':'ss zzz"
+            dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+            guard let expiresDate = dateFormatter.date(from: expiresString) else {
+                throw ServerAPIv3Error.expiresResponseHeaderIsInvalid(expiresString)
+            }
+
+            switch responseData.contentTypeResponseHeader {
+            case "application/x-openvpn-profile":
+                let configLines = configString.split(separator: "\n").map { String($0) }
+                return ServerAPIService.TunnelConfigurationData(
+                    vpnConfig: .openVPNConfig(configLines),
+                    expiresAt: expiresDate)
+            case "application/x-wireguard-profile":
+                let updatedConfigString = try insertPrivateKey(privateKey, in: configString)
+                print("configString = \(configString)")
+                print("updatedConfigString = \(updatedConfigString)")
+                return ServerAPIService.TunnelConfigurationData(
+                    vpnConfig: .wireGuardConfig(updatedConfigString),
+                    expiresAt: expiresDate)
+            default:
+                throw ServerAPIv3Error.unexpectedContentTypeOnConnect(responseData.contentTypeResponseHeader)
+            }
+        }
+    }
+}
+
+private extension ServerAPIv3Handler {
+
+    enum ServerAPITarget: TargetType, AcceptJson, AccessTokenAuthorizable {
+        case info(ServerAPIService.CommonAPIRequestInfo)
+        case connect(ServerAPIService.CommonAPIRequestInfo, profile: Profile, publicKey: String)
+        case disconnect(ServerAPIService.CommonAPIRequestInfo, profile: Profile)
+
+        var commonInfo: ServerAPIService.CommonAPIRequestInfo {
+            switch self {
+            case .info(let commonInfo): return commonInfo
+            case .connect(let commonInfo, _, _): return commonInfo
+            case .disconnect(let commonInfo, _): return commonInfo
+            }
+        }
+
+        var baseURL: URL { commonInfo.serverInfo.apiBaseURL }
+
+        var path: String {
+            switch self {
+            case .info: return "/info"
+            case .connect: return "/connect"
+            case .disconnect: return "/disconnect"
+            }
+        }
+
+        var method: Moya.Method {
+            switch self {
+            case .info: return .get
+            case .connect, .disconnect: return .post
+            }
+        }
+
+        var sampleData: Data { Data() }
+
+        var task: Task {
+            switch self {
+            case .info:
+                return .requestPlain
+            case .connect(_, let profile, let publicKey):
+                return .requestParameters(
+                    parameters: [
+                        "profile_id": profile.profileId,
+                        "public_key": publicKey,
+                    ],
+                    encoding: URLEncoding.httpBody)
+            case .disconnect(_, let profile):
+                return .requestParameters(
+                    parameters: [
+                        "profile_id": profile.profileId,
+                    ],
+                    encoding: URLEncoding.httpBody)
+            }
+        }
+
+        var authorizationType: AuthorizationType? { .bearer }
+    }
+
+    static let HTTPStatusCodeUnauthorized = 401
+
+    struct ResponseData<T: ServerResponse> {
+        let data: T.DataType
+        let contentTypeResponseHeader: String?
+        let expiresResponseHeader: String?
+    }
+
+    static func makeRequest<T: ServerResponse>(
+        target: ServerAPITarget,
+        decodeAs responseType: T.Type,
+        options: ServerAPIService.Options) -> Promise<ResponseData<T>> {
+
+        firstly { () -> Promise<String> in
+            Self.getFreshAccessToken(
+                commonInfo: target.commonInfo,
+                options: options)
+        }.then { accessToken -> Promise<Moya.Response> in
+            let authPlugin = AccessTokenPlugin { _ in accessToken }
+            let provider = MoyaProvider<ServerAPITarget>(session: target.commonInfo.session, plugins: [authPlugin])
+            return provider.request(target: target)
+        }.then { response -> Promise<ResponseData<T>> in
+            if response.statusCode == Self.HTTPStatusCodeUnauthorized &&
+                !options.contains(.ignoreStoredAuthState) {
+                os_log("Encountered HTTP status code Unauthorized", log: Log.general, type: .info)
+                return Self.makeRequest(
+                    target: target,
+                    decodeAs: responseType,
+                    options: options.union([.ignoreStoredAuthState]))
+            } else {
+                let successStatusCodes = (200...299)
+                guard successStatusCodes.contains(response.statusCode) else {
+                    throw ServerAPIv3Error.HTTPFailure(requestURLPath: target.path, response: response)
+                }
+                let data = try T(data: response.data).data
+                let httpResponse = response.response
+                let responseData = ResponseData<T>(
+                    data: data,
+                    contentTypeResponseHeader: httpResponse?.value(forHTTPHeaderField: "Content-Type"),
+                    expiresResponseHeader: httpResponse?.value(forHTTPHeaderField: "Expires"))
+                return Promise.value(responseData)
+            }
+        }
+    }
+}
+
+private extension ServerAPIv3Handler {
+    static func insertPrivateKey(
+        _ privateKey: WireGuardKit.PrivateKey,
+        in wgQuickConfig: String) throws -> String {
+
+        guard let interfaceRange = wgQuickConfig.range(of: "[Interface]") else {
+            throw ServerAPIv3Error.wgVPNConfigMissingInterfaceSection
+        }
+        var config = wgQuickConfig
+        config.insert(
+            contentsOf: "\nPrivateKey = \(privateKey.base64Key)\n",
+            at: interfaceRange.upperBound)
+        return config
+    }
+}

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -132,8 +132,6 @@ struct ServerAPIv3Handler: ServerAPIHandler {
                     serverAPIVersion: commonInfo.serverInfo.apiVersion)
             case "application/x-wireguard-profile":
                 let updatedConfigString = try insertPrivateKey(privateKey, in: configString)
-                print("configString = \(configString)")
-                print("updatedConfigString = \(updatedConfigString)")
                 return ServerAPIService.TunnelConfigurationData(
                     vpnConfig: .wireGuardConfig(updatedConfigString),
                     expiresAt: expiresDate,

--- a/EduVPN/Networking/ServerInfoFetcher.swift
+++ b/EduVPN/Networking/ServerInfoFetcher.swift
@@ -55,6 +55,7 @@ struct ServerInfoFetcher {
             let apiServerInfo = serverInfos[0]
             let authServerInfo = serverInfos[1]
             return ServerInfo(
+                apiVersion: apiServerInfo.apiVersion,
                 authorizationEndpoint: authServerInfo.authorizationEndpoint,
                 tokenEndpoint: authServerInfo.tokenEndpoint,
                 apiBaseURL: apiServerInfo.apiBaseURL)

--- a/EduVPN/Resources/Mac/Info.plist
+++ b/EduVPN/Resources/Mac/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2017-2020 The Commons Conservancy. All rights reserved.</string>
+	<string>Copyright © 2017-2021 The Commons Conservancy. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/EduVPN/Services/PersistenceService.swift
+++ b/EduVPN/Services/PersistenceService.swift
@@ -258,6 +258,10 @@ extension PersistenceService {
             rootURL.appendingPathComponent("keyPair.bin")
         }
 
+        private var wireGuardPrivateKeyURL: URL {
+            rootURL.appendingPathComponent("wgPrivateKey.bin")
+        }
+
         private var migratedClientCertificateURL: URL {
             rootURL.appendingPathComponent("client.certificate")
         }
@@ -314,6 +318,22 @@ extension PersistenceService {
                 }
                 if FileManager.default.fileExists(atPath: migratedClientCertificateURL.path) {
                     try? FileManager.default.removeItem(at: migratedClientCertificateURL)
+                }
+            }
+        }
+
+        var wireGuardPrivateKey: Data? {
+            get {
+                if let data = try? Data(contentsOf: wireGuardPrivateKeyURL),
+                    let clearTextData = Crypto.shared.decrypt(data: data) {
+                    return clearTextData
+                }
+                return nil
+            }
+            set(value) {
+                let data = value ?? Data()
+                if let encryptedData = try? Crypto.shared.encrypt(data: data) {
+                    PersistenceService.write(encryptedData, to: wireGuardPrivateKeyURL, atomically: true)
                 }
             }
         }

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -112,7 +112,7 @@ class ServerAPIService {
                                                   sourceViewController: viewController)
             return self.makeRequest(target: .profileList(basicTargetInfo),
                                     wayfSkippingInfo: wayfSkippingInfo,
-                                    decodeAs: ProfileListResponse.self,
+                                    decodeAs: ProfileListResponsev2.self,
                                     options: options)
                 .map { ($0, serverInfo) }
         }

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -32,6 +32,8 @@ class ServerAPIService {
     struct TunnelConfigurationData {
         let vpnConfig: VPNConfiguration
         let expiresAt: Date
+        let serverAPIBaseURL: URL
+        let serverAPIVersion: ServerInfo.APIVersion
     }
 
     struct CommonAPIRequestInfo {

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -32,10 +32,6 @@ class ServerAPIService {
     struct TunnelConfigurationData {
         let vpnConfig: VPNConfiguration
         let expiresAt: Date
-
-        var certificateValidityRange: CertificateValidityRange { // Temporary
-            CertificateValidityRange(validFrom: expiresAt, expiresAt: expiresAt)
-        }
     }
 
     struct CommonAPIRequestInfo {
@@ -45,11 +41,6 @@ class ServerAPIService {
         let serverAuthService: ServerAuthService
         let wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?
         let sourceViewController: AuthorizingViewController
-    }
-
-    struct CertificateValidityRange { // Temporary
-        let validFrom: Date
-        let expiresAt: Date
     }
 
     static var uncachedSession: Moya.Session {

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -13,7 +13,7 @@ import os.log
 enum ServerAPIServiceError: Error {
     case serverProvidedInvalidCertificate
     case HTTPFailure(requestURLPath: String, response: Moya.Response)
-    case errorGettingProfileConfig(profile: ProfileListResponse.Profile, serverError: String)
+    case errorGettingProfileConfig(profile: Profile, serverError: String)
     case openVPNConfigHasInvalidEncoding
     case openVPNConfigHasNoCertificateAuthority
     case openVPNConfigHasNoRemotes
@@ -101,11 +101,11 @@ class ServerAPIService {
     func getAvailableProfiles(for server: ServerInstance,
                               from viewController: AuthorizingViewController,
                               wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
-                              options: Options) -> Promise<([ProfileListResponse.Profile], ServerInfo)> {
+                              options: Options) -> Promise<([Profile], ServerInfo)> {
         return firstly {
             ServerInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
                                     authBaseURLString: server.authBaseURLString)
-        }.then { serverInfo -> Promise<([ProfileListResponse.Profile], ServerInfo)> in
+        }.then { serverInfo -> Promise<([Profile], ServerInfo)> in
             let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
             let basicTargetInfo = BasicTargetInfo(serverInfo: serverInfo,
                                                   dataStore: dataStore,
@@ -120,7 +120,7 @@ class ServerAPIService {
 
     // swiftlint:disable:next function_parameter_count
     func getTunnelConfigurationData(for server: ServerInstance, serverInfo: ServerInfo?,
-                                    profile: ProfileListResponse.Profile,
+                                    profile: Profile,
                                     from viewController: AuthorizingViewController,
                                     wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
                                     options: Options) -> Promise<TunnelConfigurationData> {
@@ -174,7 +174,7 @@ private extension ServerAPIService {
         case profileList(BasicTargetInfo)
         case createKeyPair(BasicTargetInfo, displayName: String)
         case checkCertificate(BasicTargetInfo, commonName: String)
-        case profileConfig(BasicTargetInfo, profile: ProfileListResponse.Profile)
+        case profileConfig(BasicTargetInfo, profile: Profile)
 
         var basicTargetInfo: BasicTargetInfo {
             switch self {
@@ -307,7 +307,7 @@ private extension ServerAPIService {
         }
     }
 
-    func getProfileConfig(basicTargetInfo: BasicTargetInfo, profile: ProfileListResponse.Profile,
+    func getProfileConfig(basicTargetInfo: BasicTargetInfo, profile: Profile,
                           wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
                           options: Options) -> Promise<Data> {
         firstly {

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -11,78 +11,45 @@ import ASN1Decoder
 import os.log
 
 enum ServerAPIServiceError: Error {
-    case serverProvidedInvalidCertificate
-    case HTTPFailure(requestURLPath: String, response: Moya.Response)
-    case errorGettingProfileConfig(profile: Profile, serverError: String)
-    case openVPNConfigHasInvalidEncoding
-    case openVPNConfigHasNoCertificateAuthority
-    case openVPNConfigHasNoRemotes
-    case openVPNConfigHasOnlyUDPRemotes // and UDP is not allowed
-}
-
-extension ServerAPIServiceError: AppError {
-    var summary: String {
-        switch self {
-        case .serverProvidedInvalidCertificate:
-            return "Server provided invalid certificate"
-        case .HTTPFailure:
-            return "HTTP request failed"
-        case .errorGettingProfileConfig:
-            return "Error getting profile config"
-        case .openVPNConfigHasInvalidEncoding:
-            return "OpenVPN config has unrecognized encoding"
-        case .openVPNConfigHasNoCertificateAuthority:
-            return "OpenVPN config has no certificate authority"
-        case .openVPNConfigHasNoRemotes:
-            return "OpenVPN config has no remotes"
-        case .openVPNConfigHasOnlyUDPRemotes:
-            return "OpenVPN config has no TCP remotes, but only TCP can be used as per preferences"
-        }
-    }
-
-    var detail: String {
-        switch self {
-        case .serverProvidedInvalidCertificate:
-            return "Server provided invalid certificate"
-        case .HTTPFailure(let requestURLPath, let response):
-            return """
-            Request path: \(requestURLPath)
-            Response code: \(response.statusCode)
-            Response: \(String(data: response.data, encoding: .utf8) ?? "")
-            """
-        case .errorGettingProfileConfig(let profile, let serverError):
-            return """
-            Requested profile: \(profile.displayName.stringForCurrentLanguage())
-            Server error: \(serverError)
-            """
-        default:
-            return ""
-        }
-    }
+    case cannotUseStoredAuthState
+    case cannotUseStoredKeyPair // Applies to APIv2 only
+    case unauthorized(authorizationError: Error)
 }
 
 class ServerAPIService {
-
     struct Options: OptionSet {
         let rawValue: Int
 
         static let ignoreStoredAuthState = Options(rawValue: 1 << 0)
-        static let ignoreStoredKeyPair = Options(rawValue: 1 << 1)
+        static let ignoreStoredKeyPair = Options(rawValue: 1 << 1) // APIv2 only
     }
 
-    struct CertificateValidityRange {
-        let validFrom: Date
-        let expiresAt: Date
+    enum VPNConfiguration {
+        case openVPNConfig([String])
+        case wireGuardConfig(String)
     }
 
     struct TunnelConfigurationData {
-        let openVPNConfiguration: [String]
-        let certificateValidityRange: CertificateValidityRange
+        let vpnConfig: VPNConfiguration
+        let expiresAt: Date
+
+        var certificateValidityRange: CertificateValidityRange { // Temporary
+            CertificateValidityRange(validFrom: expiresAt, expiresAt: expiresAt)
+        }
     }
 
-    struct KeyPairData {
-        let keyPair: CreateKeyPairResponse.KeyPair
-        let certificateValidityRange: CertificateValidityRange
+    struct CommonAPIRequestInfo {
+        let serverInfo: ServerInfo
+        let dataStore: PersistenceService.DataStore
+        let session: Moya.Session
+        let serverAuthService: ServerAuthService
+        let wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?
+        let sourceViewController: AuthorizingViewController
+    }
+
+    struct CertificateValidityRange { // Temporary
+        let validFrom: Date
+        let expiresAt: Date
     }
 
     static var uncachedSession: Moya.Session {
@@ -106,14 +73,18 @@ class ServerAPIService {
             ServerInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
                                     authBaseURLString: server.authBaseURLString)
         }.then { serverInfo -> Promise<([Profile], ServerInfo)> in
+            precondition(serverInfo.apiVersion == .apiv2) // APIv3 is not handled yet
             let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
-            let basicTargetInfo = BasicTargetInfo(serverInfo: serverInfo,
-                                                  dataStore: dataStore,
-                                                  sourceViewController: viewController)
-            return self.makeRequest(target: .profileList(basicTargetInfo),
-                                    wayfSkippingInfo: wayfSkippingInfo,
-                                    decodeAs: ProfileListResponsev2.self,
-                                    options: options)
+            let commonInfo = ServerAPIService.CommonAPIRequestInfo(
+                serverInfo: serverInfo,
+                dataStore: dataStore,
+                session: Self.uncachedSession,
+                serverAuthService: self.serverAuthService,
+                wayfSkippingInfo: wayfSkippingInfo,
+                sourceViewController: viewController)
+            return ServerAPIv2Handler.getAvailableProfiles(
+                commonInfo: commonInfo,
+                options: options)
                 .map { ($0, serverInfo) }
         }
     }
@@ -124,294 +95,67 @@ class ServerAPIService {
                                     from viewController: AuthorizingViewController,
                                     wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
                                     options: Options) -> Promise<TunnelConfigurationData> {
-        let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
         return firstly { () -> Promise<ServerInfo> in
             if let serverInfo = serverInfo {
                 return Promise.value(serverInfo)
             }
             return ServerInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
                                            authBaseURLString: server.authBaseURLString)
-        }.then { serverInfo -> Promise<(BasicTargetInfo, KeyPairData)> in
-            let basicTargetInfo = BasicTargetInfo(serverInfo: serverInfo,
-                                                  dataStore: dataStore,
-                                                  sourceViewController: viewController)
-            return self.getKeyPair(basicTargetInfo: basicTargetInfo,
-                                   wayfSkippingInfo: wayfSkippingInfo, options: options)
-                .map { (basicTargetInfo, $0) }
-        }.then { (basicTargetInfo, keyPairData) -> Promise<TunnelConfigurationData> in
-            // Can reuse the auth state we just got from getKeyPair
-            let updatedOptions = options.subtracting([.ignoreStoredAuthState])
-            return firstly {
-                self.getProfileConfig(basicTargetInfo: basicTargetInfo, profile: profile,
-                                      wayfSkippingInfo: wayfSkippingInfo, options: updatedOptions)
-            }.map { profileConfig in
-                let isUDPAllowed = !UserDefaults.standard.forceTCP
-                let openVPNConfig = try Self.createOpenVPNConfig(
-                    profileConfig: profileConfig, isUDPAllowed: isUDPAllowed, keyPair: keyPairData.keyPair)
-                return TunnelConfigurationData(
-                    openVPNConfiguration: openVPNConfig,
-                    certificateValidityRange: keyPairData.certificateValidityRange)
-            }
-        }
-    }
-
-}
-
-private extension ServerAPIService {
-
-    enum StoredDataError: Error {
-        case cannotUseStoredAuthState
-        case cannotUseStoredKeyPair
-    }
-
-    struct BasicTargetInfo {
-        let serverInfo: ServerInfo
-        let dataStore: PersistenceService.DataStore
-        let sourceViewController: AuthorizingViewController
-    }
-
-    enum ServerAPITarget: TargetType, AcceptJson, AccessTokenAuthorizable {
-        case profileList(BasicTargetInfo)
-        case createKeyPair(BasicTargetInfo, displayName: String)
-        case checkCertificate(BasicTargetInfo, commonName: String)
-        case profileConfig(BasicTargetInfo, profile: Profile)
-
-        var basicTargetInfo: BasicTargetInfo {
-            switch self {
-            case .profileList(let basicTargetInfo): return basicTargetInfo
-            case .createKeyPair(let basicTargetInfo, _): return basicTargetInfo
-            case .checkCertificate(let basicTargetInfo, _): return basicTargetInfo
-            case .profileConfig(let basicTargetInfo, _): return basicTargetInfo
-            }
-        }
-
-        var baseURL: URL { basicTargetInfo.serverInfo.apiBaseURL }
-
-        var path: String {
-            switch self {
-            case .profileList: return "/profile_list"
-            case .createKeyPair: return "/create_keypair"
-            case .checkCertificate: return "/check_certificate"
-            case .profileConfig: return "/profile_config"
-            }
-        }
-
-        var method: Moya.Method {
-            switch self {
-            case .profileList, .checkCertificate, .profileConfig: return .get
-            case .createKeyPair: return .post
-            }
-        }
-
-        var sampleData: Data { Data() }
-
-        var task: Task {
-            switch self {
-            case .profileList:
-                return .requestPlain
-            case .createKeyPair(_, let displayName):
-                return .requestParameters(
-                    parameters: ["display_name": displayName],
-                    encoding: URLEncoding.httpBody)
-            case .checkCertificate(_, let commonName):
-                return .requestParameters(
-                    parameters: ["common_name": commonName],
-                    encoding: URLEncoding.queryString)
-            case .profileConfig(_, let profile):
-                return .requestParameters(
-                    parameters: ["profile_id": profile.profileId],
-                    encoding: URLEncoding.queryString)
-            }
-        }
-
-        var authorizationType: AuthorizationType? { .bearer }
-    }
-
-    static let HTTPStatusCodeUnauthorized = 401
-
-    func makeRequest<T: ServerResponse>(target: ServerAPITarget,
-                                        wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
-                                        decodeAs responseType: T.Type,
-                                        options: Options) -> Promise<T.DataType> {
-        firstly { () -> Promise<String> in
-            self.getFreshAccessToken(
-                basicTargetInfo: target.basicTargetInfo,
-                wayfSkippingInfo: wayfSkippingInfo, options: options)
-        }.then { accessToken -> Promise<Moya.Response> in
-            let authPlugin = AccessTokenPlugin { _ in accessToken }
-            let provider = MoyaProvider<ServerAPITarget>(session: Self.uncachedSession, plugins: [authPlugin])
-            return provider.request(target: target)
-        }.then { response -> Promise<T.DataType> in
-            if response.statusCode == Self.HTTPStatusCodeUnauthorized &&
-                !options.contains(.ignoreStoredAuthState) {
-                os_log("Encountered HTTP status code Unauthorized", log: Log.general, type: .info)
-                return self.makeRequest(target: target, wayfSkippingInfo: wayfSkippingInfo,
-                                        decodeAs: responseType,
-                                        options: options.union([.ignoreStoredAuthState]))
-            } else {
-                let successStatusCodes = (200...299)
-                guard successStatusCodes.contains(response.statusCode) else {
-                    throw ServerAPIServiceError.HTTPFailure(requestURLPath: target.path, response: response)
-                }
-                return Promise.value(try T(data: response.data).data)
-            }
-        }
-    }
-
-    func getKeyPair(basicTargetInfo: BasicTargetInfo,
-                    wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
-                    options: Options) -> Promise<KeyPairData> {
-        firstly { () -> Promise<KeyPairData> in
-            guard !options.contains(.ignoreStoredKeyPair),
-                let storedKeyPair = basicTargetInfo.dataStore.keyPair,
-                let certificateData = storedKeyPair.certificate.data(using: .utf8),
-                let x509Certificate = try? X509Certificate(data: certificateData),
-                x509Certificate.isCurrentlyValid,
-                let commonName = x509Certificate.commonName,
-                let expiresAt = x509Certificate.expiresAt,
-                let validFrom = x509Certificate.validFrom else {
-                    throw StoredDataError.cannotUseStoredKeyPair
-            }
-            return makeRequest(
-                target: .checkCertificate(basicTargetInfo, commonName: commonName),
+        }.then { serverInfo -> Promise<TunnelConfigurationData> in
+            precondition(serverInfo.apiVersion == .apiv2) // APIv3 is not handled yet
+            let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
+            let commonInfo = ServerAPIService.CommonAPIRequestInfo(
+                serverInfo: serverInfo,
+                dataStore: dataStore,
+                session: Self.uncachedSession,
+                serverAuthService: self.serverAuthService,
                 wayfSkippingInfo: wayfSkippingInfo,
-                decodeAs: CheckCertificateResponse.self, options: options)
-                .map { certificateValidity in
-                    guard certificateValidity.isValid else {
-                        throw StoredDataError.cannotUseStoredKeyPair
-                    }
-                    let validityRange = CertificateValidityRange(validFrom: validFrom, expiresAt: expiresAt)
-                    return KeyPairData(keyPair: storedKeyPair, certificateValidityRange: validityRange)
-                }
-        }.recover { error -> Promise<KeyPairData> in
-            if case StoredDataError.cannotUseStoredKeyPair = error {
-                return self.makeRequest(
-                    target: .createKeyPair(basicTargetInfo, displayName: Config.shared.appName),
-                    wayfSkippingInfo: wayfSkippingInfo,
-                    decodeAs: CreateKeyPairResponse.self, options: options)
-                    .map { keyPair in
-                        basicTargetInfo.dataStore.keyPair = keyPair
-                        guard let certificateData = keyPair.certificate.data(using: .utf8),
-                            let x509Certificate = try? X509Certificate(data: certificateData),
-                            x509Certificate.isCurrentlyValid,
-                            let expiresAt = x509Certificate.expiresAt,
-                            let validFrom = x509Certificate.validFrom else {
-                                throw ServerAPIServiceError.serverProvidedInvalidCertificate
-                        }
-                        let validityRange = CertificateValidityRange(validFrom: validFrom, expiresAt: expiresAt)
-                        return KeyPairData(keyPair: keyPair, certificateValidityRange: validityRange)
-                    }
-            } else {
-                throw error
-            }
+                sourceViewController: viewController)
+            return ServerAPIv2Handler.getTunnelConfigurationData(
+                commonInfo: commonInfo, profile: profile, options: options)
         }
-    }
-
-    func getProfileConfig(basicTargetInfo: BasicTargetInfo, profile: Profile,
-                          wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
-                          options: Options) -> Promise<Data> {
-        firstly {
-            makeRequest(target: .profileConfig(basicTargetInfo, profile: profile),
-                        wayfSkippingInfo: wayfSkippingInfo,
-                        decodeAs: ProfileConfigResponse.self, options: options)
-        }.map { data in
-            if let errorResponse = try? JSONDecoder().decode(ProfileConfigErrorResponse.self, from: data) {
-                throw ServerAPIServiceError.errorGettingProfileConfig(profile: profile, serverError: errorResponse.errorMessage)
-            }
-            return data
-        }
-    }
-
-    static func createOpenVPNConfig(
-        profileConfig profileConfigData: Data,
-        isUDPAllowed: Bool,
-        keyPair: CreateKeyPairResponse.KeyPair) throws -> [String] {
-
-        guard let originalConfig = String(data: profileConfigData, encoding: .utf8) else {
-            throw ServerAPIServiceError.openVPNConfigHasInvalidEncoding
-        }
-
-        let originalConfigLines = originalConfig.components(separatedBy: .newlines)
-        let privateKeyLines = keyPair.privateKey.components(separatedBy: .newlines)
-        let certificateLines = keyPair.certificate.components(separatedBy: .newlines)
-
-        var hasCA = false
-        var hasRemote = false
-
-        var processedLines = [String]()
-        for originalLine in originalConfigLines {
-            let line = originalLine.trimmingCharacters(in: .whitespacesAndNewlines)
-            if line.isEmpty { continue }
-            if line.hasSuffix("auth none") { continue }
-
-            if line.hasSuffix("</ca>") {
-                processedLines.append(line)
-                processedLines.append("<cert>")
-                processedLines.append(contentsOf: certificateLines)
-                processedLines.append("</cert>")
-                processedLines.append("<key>")
-                processedLines.append(contentsOf: privateKeyLines)
-                processedLines.append("</key>")
-                hasCA = true
-                continue
-            }
-
-            if line.hasPrefix("remote") {
-                let isUDPOnlyRemote = (line.hasSuffix(" udp") || line.hasSuffix(" udp4") || line.hasSuffix(" udp6"))
-                if !isUDPOnlyRemote || isUDPAllowed {
-                    processedLines.append(line)
-                    hasRemote = true
-                }
-                continue
-            }
-
-            processedLines.append(line)
-        }
-
-        guard hasCA else {
-            throw ServerAPIServiceError.openVPNConfigHasNoCertificateAuthority
-        }
-
-        guard hasRemote else {
-            throw ServerAPIServiceError.openVPNConfigHasNoRemotes
-        }
-
-        return processedLines
     }
 }
 
-private extension ServerAPIService {
+protocol ServerAPIHandler {
+    static var authStateChangeHandler: AuthStateChangeHandler? { get set }
+    static func getAvailableProfiles(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        options: ServerAPIService.Options) -> Promise<[Profile]>
+    static func getTunnelConfigurationData(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        profile: Profile,
+        options: ServerAPIService.Options) -> Promise<ServerAPIService.TunnelConfigurationData>
+}
 
-    enum AuthStateError: Error {
-        case authStateUnauthorized(authorizationError: Error)
-    }
+extension ServerAPIHandler {
+    static func getFreshAccessToken(
+        commonInfo: ServerAPIService.CommonAPIRequestInfo,
+        options: ServerAPIService.Options) -> Promise<String> {
 
-    func getFreshAccessToken(basicTargetInfo: BasicTargetInfo,
-                             wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
-                             options: Options) -> Promise<String> {
         return firstly { () -> Promise<String> in
             if options.contains(.ignoreStoredAuthState) {
-                throw StoredDataError.cannotUseStoredAuthState
+                throw ServerAPIServiceError.cannotUseStoredAuthState
             }
-            guard let authState = basicTargetInfo.dataStore.authState else {
-                throw StoredDataError.cannotUseStoredAuthState
+            guard let authState = commonInfo.dataStore.authState else {
+                throw ServerAPIServiceError.cannotUseStoredAuthState
             }
-            return self.getFreshAccessToken(using: authState, storingChangesTo: basicTargetInfo.dataStore)
+            return self.getFreshAccessToken(using: authState, storingChangesTo: commonInfo.dataStore)
         }.recover { error -> Promise<String> in
             os_log("Error getting access token: %{public}@", log: Log.general, type: .error,
                    error.localizedDescription)
             switch error {
-            case StoredDataError.cannotUseStoredAuthState,
-                 AuthStateError.authStateUnauthorized:
+            case ServerAPIServiceError.cannotUseStoredAuthState,
+                 ServerAPIServiceError.unauthorized:
                 os_log("Starting fresh authentication", log: Log.general, type: .info)
-                return self.serverAuthService.startAuth(
-                    authEndpoint: basicTargetInfo.serverInfo.authorizationEndpoint,
-                    tokenEndpoint: basicTargetInfo.serverInfo.tokenEndpoint,
-                    from: basicTargetInfo.sourceViewController,
-                    wayfSkippingInfo: wayfSkippingInfo)
+                return commonInfo.serverAuthService.startAuth(
+                    authEndpoint: commonInfo.serverInfo.authorizationEndpoint,
+                    tokenEndpoint: commonInfo.serverInfo.tokenEndpoint,
+                    from: commonInfo.sourceViewController,
+                    wayfSkippingInfo: commonInfo.wayfSkippingInfo)
                 .then { authState -> Promise<String> in
-                    basicTargetInfo.dataStore.authState = authState
-                    return self.getFreshAccessToken(using: authState, storingChangesTo: basicTargetInfo.dataStore)
+                    commonInfo.dataStore.authState = authState
+                    return self.getFreshAccessToken(using: authState, storingChangesTo: commonInfo.dataStore)
                 }
             default:
                 throw error
@@ -419,18 +163,19 @@ private extension ServerAPIService {
         }
     }
 
-    func getFreshAccessToken(using authState: AuthState,
-                             storingChangesTo dataStore: PersistenceService.DataStore)
-        -> Promise<String> {
+    static func getFreshAccessToken(
+        using authState: AuthState,
+        storingChangesTo dataStore: PersistenceService.DataStore) -> Promise<String> {
+
         return Promise { seal in
             let authStateChangeHandler = AuthStateChangeHandler(dataStore: dataStore)
             authState.oidAuthState.stateChangeDelegate = authStateChangeHandler
-            self.authStateChangeHandler = authStateChangeHandler
-            authState.oidAuthState.performAction { [weak self] (accessToken, _, error) in
+            Self.authStateChangeHandler = authStateChangeHandler
+            authState.oidAuthState.performAction { (accessToken, _, error) in
                 authState.oidAuthState.stateChangeDelegate = nil
-                self?.authStateChangeHandler = nil
+                Self.authStateChangeHandler = nil
                 if let authorizationError = authState.oidAuthState.authorizationError {
-                    let error = AuthStateError.authStateUnauthorized(
+                    let error = ServerAPIServiceError.unauthorized(
                         authorizationError: authorizationError)
                     seal.reject(error)
                 } else {
@@ -441,7 +186,7 @@ private extension ServerAPIService {
     }
 }
 
-private class AuthStateChangeHandler: NSObject, OIDAuthStateChangeDelegate {
+class AuthStateChangeHandler: NSObject, OIDAuthStateChangeDelegate {
     let dataStore: PersistenceService.DataStore
 
     init(dataStore: PersistenceService.DataStore) {
@@ -451,22 +196,4 @@ private class AuthStateChangeHandler: NSObject, OIDAuthStateChangeDelegate {
     func didChange(_ state: OIDAuthState) {
         dataStore.authState = AuthState(oidAuthState: state)
     }
-}
-
-private extension X509Certificate {
-    var isCurrentlyValid: Bool {
-        return checkValidity()
-    }
-
-    var commonName: String? {
-        if let commonNameElements = subjectDistinguishedName?.split(separator: "=") {
-            if commonNameElements.count == 2 && commonNameElements[0] == "CN" {
-                return String(commonNameElements[1])
-            }
-        }
-        return nil
-    }
-
-    var validFrom: Date? { notBefore }
-    var expiresAt: Date? { notAfter }
 }

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -117,6 +117,17 @@ class ServerAPIService {
                 commonInfo: commonInfo, profile: profile, options: options)
         }
     }
+
+    func attemptToRelinquishTunnelConfiguration(
+        apiVersion: ServerInfo.APIVersion,
+        baseURL: URL, dataStore: PersistenceService.DataStore,
+        profile: Profile) {
+
+        let serverAPIHandler = Self.serverAPIHandlerType(for: apiVersion)
+        serverAPIHandler.attemptToRelinquishTunnelConfiguration(
+            baseURL: baseURL, dataStore: dataStore,
+            session: Self.uncachedSession, profile: profile)
+    }
 }
 
 protocol ServerAPIHandler {
@@ -128,6 +139,9 @@ protocol ServerAPIHandler {
         commonInfo: ServerAPIService.CommonAPIRequestInfo,
         profile: Profile,
         options: ServerAPIService.Options) -> Promise<ServerAPIService.TunnelConfigurationData>
+    static func attemptToRelinquishTunnelConfiguration(
+        baseURL: URL, dataStore: PersistenceService.DataStore, session: Moya.Session,
+        profile: Profile)
 }
 
 extension ServerAPIHandler {

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -56,6 +56,15 @@ class ServerAPIService {
         self.serverAuthService = serverAuthService
     }
 
+    private static func serverAPIHandlerType(for apiVersion: ServerInfo.APIVersion) -> ServerAPIHandler.Type {
+        switch apiVersion {
+        case .apiv2:
+            return ServerAPIv2Handler.self
+        case .apiv3:
+            return ServerAPIv3Handler.self
+        }
+    }
+
     func getAvailableProfiles(for server: ServerInstance,
                               from viewController: AuthorizingViewController,
                               wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
@@ -64,7 +73,6 @@ class ServerAPIService {
             ServerInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
                                     authBaseURLString: server.authBaseURLString)
         }.then { serverInfo -> Promise<([Profile], ServerInfo)> in
-            precondition(serverInfo.apiVersion == .apiv2) // APIv3 is not handled yet
             let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
             let commonInfo = ServerAPIService.CommonAPIRequestInfo(
                 serverInfo: serverInfo,
@@ -73,7 +81,8 @@ class ServerAPIService {
                 serverAuthService: self.serverAuthService,
                 wayfSkippingInfo: wayfSkippingInfo,
                 sourceViewController: viewController)
-            return ServerAPIv2Handler.getAvailableProfiles(
+            let serverAPIHandler = Self.serverAPIHandlerType(for: serverInfo.apiVersion)
+            return serverAPIHandler.getAvailableProfiles(
                 commonInfo: commonInfo,
                 options: options)
                 .map { ($0, serverInfo) }
@@ -93,7 +102,6 @@ class ServerAPIService {
             return ServerInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
                                            authBaseURLString: server.authBaseURLString)
         }.then { serverInfo -> Promise<TunnelConfigurationData> in
-            precondition(serverInfo.apiVersion == .apiv2) // APIv3 is not handled yet
             let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
             let commonInfo = ServerAPIService.CommonAPIRequestInfo(
                 serverInfo: serverInfo,
@@ -102,7 +110,8 @@ class ServerAPIService {
                 serverAuthService: self.serverAuthService,
                 wayfSkippingInfo: wayfSkippingInfo,
                 sourceViewController: viewController)
-            return ServerAPIv2Handler.getTunnelConfigurationData(
+            let serverAPIHandler = Self.serverAPIHandlerType(for: serverInfo.apiVersion)
+            return serverAPIHandler.getTunnelConfigurationData(
                 commonInfo: commonInfo, profile: profile, options: options)
         }
     }

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -246,7 +246,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
             connectingProfile = preConnectionState.profiles
                 .first(where: { $0.profileId == preConnectionState.selectedProfileId })
             certificateExpiryHelper = CertificateExpiryHelper(
-                expiresAt: preConnectionState.certificateExpiresAt,
+                expiresAt: preConnectionState.sessionExpiresAt,
                 handler: { [weak self] certificateStatus in
                     self?.certificateStatus = certificateStatus
                 })
@@ -372,7 +372,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 server: server,
                 profiles: self.profiles ?? [],
                 selectedProfileId: profile.profileId,
-                certificateValidityRange: tunnelConfigData.certificateValidityRange,
+                sessionExpiresAt: tunnelConfigData.expiresAt,
                 attemptId: connectionAttemptId)
             self.delegate?.connectionViewModel(self, willAttemptToConnect: connectionAttempt)
             switch tunnelConfigData.vpnConfig {

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -12,7 +12,7 @@ import NetworkExtension
 protocol ConnectionViewModelDelegate: class {
     func connectionViewModel(
         _ model: ConnectionViewModel,
-        foundProfiles profiles: [ProfileListResponse.Profile])
+        foundProfiles profiles: [Profile])
     func connectionViewModel(
         _ model: ConnectionViewModel,
         canGoBackChanged canGoBack: Bool)
@@ -92,7 +92,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
 
     enum AdditionalControl {
         case none
-        case profileSelector([ProfileListResponse.Profile])
+        case profileSelector([Profile])
         case renewSessionButton
         case setCredentialsButton
         case spinner
@@ -163,7 +163,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
         }
     }
 
-    private var profiles: [ProfileListResponse.Profile]? {
+    private var profiles: [Profile]? {
         didSet {
             self.updateStatusDetail()
             self.updateVPNSwitchState()
@@ -209,7 +209,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
     private let authURLTemplate: String?
 
     private let dataStore: PersistenceService.DataStore
-    private var connectingProfile: ProfileListResponse.Profile?
+    private var connectingProfile: Profile?
 
     private var vpnConfigCredentials: Credentials?
     private var shouldAskForPasswordOnReconnect: Bool = false
@@ -297,7 +297,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
               let serverAPIService = serverAPIService else {
             return Promise.value(())
         }
-        return firstly { () -> Promise<([ProfileListResponse.Profile], ServerInfo)> in
+        return firstly { () -> Promise<([Profile], ServerInfo)> in
             self.internalState = .gettingProfiles
             return serverAPIService.getAvailableProfiles(
                 for: server, from: viewController,
@@ -319,7 +319,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                     self.internalState = .idle
                     return Promise.value(())
                 }
-                let profile: ProfileListResponse.Profile = {
+                let profile: Profile = {
                     if let preferredProfileId = preferredProfileId {
                         return profiles.first(where: { $0.profileId == preferredProfileId }) ?? firstProfile
                     } else {
@@ -341,7 +341,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
     }
 
     func continueServerConnectionFlow(
-        profile: ProfileListResponse.Profile,
+        profile: Profile,
         from viewController: AuthorizingViewController,
         serverInfo: ServerInfo? = nil,
         serverAPIOptions: ServerAPIService.Options = []) -> Promise<Void> {

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -340,6 +340,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func continueServerConnectionFlow(
         profile: Profile,
         from viewController: AuthorizingViewController,
@@ -377,13 +378,18 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 certificateValidityRange: tunnelConfigData.certificateValidityRange,
                 attemptId: connectionAttemptId)
             self.delegate?.connectionViewModel(self, willAttemptToConnect: connectionAttempt)
-            return self.connectionService.enableVPN(
-                openVPNConfig: tunnelConfigData.openVPNConfiguration,
-                connectionAttemptId: connectionAttemptId,
-                credentials: nil,
-                shouldDisableVPNOnError: true,
-                shouldPreventAutomaticConnections: false)
-                .map { (expiresAt, connectionAttemptId) }
+            switch tunnelConfigData.vpnConfig {
+            case .openVPNConfig(let configLines):
+                return self.connectionService.enableVPN(
+                    openVPNConfig: configLines,
+                    connectionAttemptId: connectionAttemptId,
+                    credentials: nil,
+                    shouldDisableVPNOnError: true,
+                    shouldPreventAutomaticConnections: false)
+                    .map { (expiresAt, connectionAttemptId) }
+            default:
+                fatalError("WireGuard profiles not supported yet")
+            }
         }.then { (expiresAt, connectionAttemptId) -> Promise<Void> in
             self.internalState = self.connectionService.isVPNEnabled ? .enabledVPN : .idle
             guard let notificationService = self.notificationService else {

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -361,7 +361,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 options: serverAPIOptions)
         }.then { tunnelConfigData -> Promise<(Date, UUID)> in
             self.internalState = .enableVPNRequested
-            let expiresAt = tunnelConfigData.certificateValidityRange.expiresAt
+            let expiresAt = tunnelConfigData.expiresAt
             self.certificateExpiryHelper = CertificateExpiryHelper(
                 expiresAt: expiresAt,
                 handler: { [weak self] certificateStatus in

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -384,8 +384,13 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                     shouldDisableVPNOnError: true,
                     shouldPreventAutomaticConnections: false)
                     .map { (expiresAt, connectionAttemptId) }
-            default:
-                fatalError("WireGuard profiles not supported yet")
+            case .wireGuardConfig(let configString):
+                return self.connectionService.enableVPN(
+                    wireGuardConfig: configString,
+                    serverName: serverInfo?.apiBaseURL.host ?? "",
+                    connectionAttemptId: connectionAttemptId,
+                    shouldDisableVPNOnError: true)
+                    .map { (expiresAt, connectionAttemptId) }
             }
         }.then { (expiresAt, connectionAttemptId) -> Promise<Void> in
             self.internalState = self.connectionService.isVPNEnabled ? .enabledVPN : .idle

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -472,6 +472,13 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
             return self.connectionService.disableVPN()
         }.map {
             self.notificationService?.descheduleSessionExpiryNotification()
+            if let serverInfoForDisconnectReport = self.serverInfoForDisconnectReport,
+               let profile = self.connectingProfile {
+                self.serverAPIService?.attemptToRelinquishTunnelConfiguration(
+                    apiVersion: serverInfoForDisconnectReport.serverAPIVersion,
+                    baseURL: serverInfoForDisconnectReport.serverAPIBaseURL,
+                    dataStore: self.dataStore, profile: profile)
+            }
         }.ensure {
             self.internalState = self.connectionService.isVPNEnabled ? .enabledVPN : .idle
             if self.internalState == .idle {

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -246,7 +246,6 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
             connectingProfile = preConnectionState.profiles
                 .first(where: { $0.profileId == preConnectionState.selectedProfileId })
             certificateExpiryHelper = CertificateExpiryHelper(
-                validFrom: preConnectionState.certificateValidFrom,
                 expiresAt: preConnectionState.certificateExpiresAt,
                 handler: { [weak self] certificateStatus in
                     self?.certificateStatus = certificateStatus
@@ -362,10 +361,8 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 options: serverAPIOptions)
         }.then { tunnelConfigData -> Promise<(Date, UUID)> in
             self.internalState = .enableVPNRequested
-            let validFrom = tunnelConfigData.certificateValidityRange.validFrom
             let expiresAt = tunnelConfigData.certificateValidityRange.expiresAt
             self.certificateExpiryHelper = CertificateExpiryHelper(
-                validFrom: validFrom,
                 expiresAt: expiresAt,
                 handler: { [weak self] certificateStatus in
                     self?.certificateStatus = certificateStatus

--- a/LoginItemHelper-macOS/Info.plist
+++ b/LoginItemHelper-macOS/Info.plist
@@ -27,7 +27,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2017-2020 Commons Conservancy.</string>
+	<string>Copyright © 2017-2021 Commons Conservancy.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/OpenVPNTunnelExtension-macOS/Info.plist
+++ b/OpenVPNTunnelExtension-macOS/Info.plist
@@ -30,6 +30,6 @@
 		<string>$(PRODUCT_MODULE_NAME).PacketTunnelProvider</string>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2017-2020 Commons Conservancy.</string>
+	<string>Copyright © 2017-2021 Commons Conservancy.</string>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@ The exact behavior is defined in the script [set_build_number.sh](Scripts/set_bu
 
 ## Dependencies
 
-Dependencies are managed with CocoaPods. But this repository is set up in such a way that you do not need CocoaPods to build this project, only when updating dependencies.
+### CocoaPods
+
+Most dependencies are managed with CocoaPods. But this repository is set up in such a way that you do not need CocoaPods to build this project, only when updating dependencies.
 Dependencies are defined in a [Podfile](https://github.com/eduvpn/ios/blob/master/Podfile), exact versions are 'locked' in [Podfile.lock](https://github.com/eduvpn/ios/blob/master/Podfile.lock). All dependencies defined in the Podfile are committed to this repository.
+
+### Swift Package Manager
+
+WireGuardKit alone is managed with Swift Package Manager, tied to either a specific version or commit.
 
 ## Building
 
@@ -54,6 +60,28 @@ and iOS:
   - For iOS:
       - `Config/iOS/config.json`
       - `Config/iOS/Developer.xcconfig`
+
+### Pre-requisites
+
+ 1. SwiftLint and Go need to be installed. The build setup looks for these in the paths that HomeBrew installs into.
+
+    To install, run:
+    ~~~
+    brew install swiftlint go
+    ~~~
+
+    Go version 1.16 is required.
+
+ 2. An explicit App ID needs to be created at the Apple Developer website for each platform
+
+    To do this, you can:
+
+     1. Go to your [Apple Developer account page](https://developer.apple.com/account/)
+     2. Go to Certificates, IDs and Profiles > Identifiers
+     3. Create an _App ID_ with an _Explicit_ _Bundle ID_, with the following _Capabilities_:
+          - App Groups
+          - Network Extensions
+     4. Specify the _Bundle ID_ in the appropriate `Developer*.xcconfig` file as described below
 
 ### Building the eduVPN macOS app
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The app contains a [Network Tunneling Protocol Client](https://developer.apple.c
 
 ## License
 
-Copyright (c) 2020 The Commons Conservancy. All rights reserved.
+Copyright (c) 2020-2021 The Commons Conservancy. All rights reserved.
 
 ### Part I
 

--- a/Scripts/build_wireguard_go_bridge.sh
+++ b/Scripts/build_wireguard_go_bridge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # build_wireguard_go_bridge.sh - Builds WireGuardKitGo
 #
@@ -32,5 +32,9 @@ if [ -e "$checkouts_dir"/wireguard-apple ]; then
 fi
 
 wireguard_go_dir="$checkouts_dir"/Sources/WireGuardKitGo
+
+# To ensure we have Go in our path, we add where
+# Homebrew generally installs executables
+export PATH=${PATH}:/usr/local/bin:/opt/homebrew/bin
 
 cd "$wireguard_go_dir" && /usr/bin/make

--- a/WireGuardTunnelExtension/PacketTunnelProvider.swift
+++ b/WireGuardTunnelExtension/PacketTunnelProvider.swift
@@ -2,8 +2,7 @@
 //  PacketTunnelProvider.swift
 //  WireGuardTunnelExtension-macOS
 //
-//  Created by Roopesh Chander on 26/05/21.
-//  Copyright © 2021 SURFNet. All rights reserved.
+//  Copyright © 2020-2021 The Commons Conservancy. All rights reserved.
 //
 
 import NetworkExtension


### PR DESCRIPTION
~~Tested on macOS only. Not tested on iOS yet. Hence in draft.~~

Adds basic support for APIv3 (OpenVPN and WireGuard; iOS and macOS).

No logging or Connection Info yet for WireGuard tunnels.

