### PR TITLE
Force OCSP Stapling

### DIFF
--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -6,6 +6,7 @@
 import Foundation
 import AppAuth
 import Moya
+import Alamofire
 import PromiseKit
 import ASN1Decoder
 import os.log
@@ -45,10 +46,22 @@ class ServerAPIService {
         let sourceViewController: AuthorizingViewController
     }
 
+    class OCSPStaplingEnforcedTrustManager: ServerTrustManager {
+        init() {
+            super.init(allHostsMustBeEvaluated: true, evaluators: [:])
+        }
+        override func serverTrustEvaluator(forHost host: String) throws -> ServerTrustEvaluating? {
+            return RevocationTrustEvaluator(options: [.ocsp, .requirePositiveResponse])
+        }
+    }
+
     static var uncachedSession: Moya.Session {
         let configuration = URLSessionConfiguration.default
         configuration.urlCache = nil
-        return Session(configuration: configuration, startRequestsImmediately: false)
+        return Session(
+            configuration: configuration,
+            startRequestsImmediately: false,
+            serverTrustManager: OCSPStaplingEnforcedTrustManager())
     }
 
     private let serverAuthService: ServerAuthService


### PR DESCRIPTION
Implement forcing of OCSP stapling while using the server API (for #410). (Alamofire implements the revocation stuff, so it was a lot easier than I thought.)

The server API calls work, but I'm not sure if the OCSP stapling is enforced correctly. Maybe we can merge this and then @fkooman can help test it?
