### PR TITLE
macOS: Richer app menu to enable keyboard navigation

### DIFF
--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		6F21F40B26899B7A00C157E1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
 		6F21F4172689B3B700C157E1 /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D85C422B706A4006E9540 /* PacketTunnelProvider.swift */; };
 		6F25F8D2269D763F00FA8FAB /* ConnectionViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */; };
+		6F25F8D4269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25F8D3269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift */; };
 		6F305A59254AA6C60067E744 /* LogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F305A58254AA6C50067E744 /* LogViewController.swift */; };
 		6F3073572689B8000083EEEF /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3073562689B8000083EEEF /* Shared.swift */; };
 		6F3073582689B8070083EEEF /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3073562689B8000083EEEF /* Shared.swift */; };
@@ -386,6 +387,7 @@
 		6F21F40926899B7A00C157E1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		6F21F4162689B2E900C157E1 /* OpenVPNTunnelExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenVPNTunnelExtension.entitlements; sourceTree = "<group>"; };
 		6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionViewController+macOS.swift"; sourceTree = "<group>"; };
+		6F25F8D3269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCommandRespondingViewController.swift; sourceTree = "<group>"; };
 		6F305A58254AA6C50067E744 /* LogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewController.swift; sourceTree = "<group>"; };
 		6F3073562689B8000083EEEF /* Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
 		6F30735D2689E0530083EEEF /* TunnelConfiguration+UapiConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TunnelConfiguration+UapiConfig.swift"; sourceTree = "<group>"; };
@@ -864,6 +866,7 @@
 				6F8AEE7825E6D507001A603B /* StatusItemConnectionInfoHelper.swift */,
 				6F9CE540261802F10065E4BA /* CredentialsViewController+macOS.swift */,
 				6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */,
+				6F25F8D3269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift */,
 			);
 			path = Mac;
 			sourceTree = "<group>";
@@ -2219,6 +2222,7 @@
 				6F939F3F25C7D02C001887BA /* PasswordEntryViewController.swift in Sources */,
 				6F71FBBE249CCE9E0010D0FE /* DiscoveryDataFetcher.swift in Sources */,
 				6FADF82F24ADF85F00B75E8D /* Crypto.swift in Sources */,
+				6F25F8D4269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift in Sources */,
 				C7DB4C7724806512009932B1 /* eduVPN_2.xcdatamodeld in Sources */,
 				C7DB4BFD24804C85009932B1 /* Config.swift in Sources */,
 				6FCCC577249E25F100F0F5A3 /* NavigationController.swift in Sources */,

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		6F21F40A26899B7A00C157E1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
 		6F21F40B26899B7A00C157E1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
 		6F21F4172689B3B700C157E1 /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D85C422B706A4006E9540 /* PacketTunnelProvider.swift */; };
+		6F25F8D2269D763F00FA8FAB /* ConnectionViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */; };
 		6F305A59254AA6C60067E744 /* LogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F305A58254AA6C50067E744 /* LogViewController.swift */; };
 		6F3073572689B8000083EEEF /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3073562689B8000083EEEF /* Shared.swift */; };
 		6F3073582689B8070083EEEF /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3073562689B8000083EEEF /* Shared.swift */; };
@@ -384,6 +385,7 @@
 		6F1A1C0024EE8EDB0040D6A2 /* SupportContactTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportContactTextView.swift; sourceTree = "<group>"; };
 		6F21F40926899B7A00C157E1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		6F21F4162689B2E900C157E1 /* OpenVPNTunnelExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenVPNTunnelExtension.entitlements; sourceTree = "<group>"; };
+		6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionViewController+macOS.swift"; sourceTree = "<group>"; };
 		6F305A58254AA6C50067E744 /* LogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewController.swift; sourceTree = "<group>"; };
 		6F3073562689B8000083EEEF /* Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
 		6F30735D2689E0530083EEEF /* TunnelConfiguration+UapiConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TunnelConfiguration+UapiConfig.swift"; sourceTree = "<group>"; };
@@ -861,6 +863,7 @@
 				6F939F3E25C7D02C001887BA /* PasswordEntryViewController.swift */,
 				6F8AEE7825E6D507001A603B /* StatusItemConnectionInfoHelper.swift */,
 				6F9CE540261802F10065E4BA /* CredentialsViewController+macOS.swift */,
+				6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */,
 			);
 			path = Mac;
 			sourceTree = "<group>";
@@ -2187,6 +2190,7 @@
 				C7DB4B9F247FC23D009932B1 /* ConnectionViewController.swift in Sources */,
 				6F9CE541261802F10065E4BA /* CredentialsViewController+macOS.swift in Sources */,
 				6FE5668D259089800008D0D3 /* OpenVPNConfigImportHelper.swift in Sources */,
+				6F25F8D2269D763F00FA8FAB /* ConnectionViewController+macOS.swift in Sources */,
 				6F50CEBA2679E3C4008A38BA /* ServerAPIv3Handler.swift in Sources */,
 				6F36A79B24B6ED5D00BA8F5E /* SearchViewController+macOS.swift in Sources */,
 				6FADF82D24ADF6C600B75E8D /* ConnectableInstance.swift in Sources */,

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		6F21F40B26899B7A00C157E1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
 		6F21F4172689B3B700C157E1 /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D85C422B706A4006E9540 /* PacketTunnelProvider.swift */; };
 		6F25F8D2269D763F00FA8FAB /* ConnectionViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */; };
-		6F25F8D4269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25F8D3269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift */; };
+		6F25F8D4269DE3BB00FA8FAB /* MenuCommandResponding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25F8D3269DE3BB00FA8FAB /* MenuCommandResponding.swift */; };
 		6F305A59254AA6C60067E744 /* LogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F305A58254AA6C50067E744 /* LogViewController.swift */; };
 		6F3073572689B8000083EEEF /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3073562689B8000083EEEF /* Shared.swift */; };
 		6F3073582689B8070083EEEF /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3073562689B8000083EEEF /* Shared.swift */; };
@@ -387,7 +387,7 @@
 		6F21F40926899B7A00C157E1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		6F21F4162689B2E900C157E1 /* OpenVPNTunnelExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenVPNTunnelExtension.entitlements; sourceTree = "<group>"; };
 		6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionViewController+macOS.swift"; sourceTree = "<group>"; };
-		6F25F8D3269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCommandRespondingViewController.swift; sourceTree = "<group>"; };
+		6F25F8D3269DE3BB00FA8FAB /* MenuCommandResponding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCommandResponding.swift; sourceTree = "<group>"; };
 		6F305A58254AA6C50067E744 /* LogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewController.swift; sourceTree = "<group>"; };
 		6F3073562689B8000083EEEF /* Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
 		6F30735D2689E0530083EEEF /* TunnelConfiguration+UapiConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TunnelConfiguration+UapiConfig.swift"; sourceTree = "<group>"; };
@@ -866,7 +866,7 @@
 				6F8AEE7825E6D507001A603B /* StatusItemConnectionInfoHelper.swift */,
 				6F9CE540261802F10065E4BA /* CredentialsViewController+macOS.swift */,
 				6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */,
-				6F25F8D3269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift */,
+				6F25F8D3269DE3BB00FA8FAB /* MenuCommandResponding.swift */,
 			);
 			path = Mac;
 			sourceTree = "<group>";
@@ -2222,7 +2222,7 @@
 				6F939F3F25C7D02C001887BA /* PasswordEntryViewController.swift in Sources */,
 				6F71FBBE249CCE9E0010D0FE /* DiscoveryDataFetcher.swift in Sources */,
 				6FADF82F24ADF85F00B75E8D /* Crypto.swift in Sources */,
-				6F25F8D4269DE3BB00FA8FAB /* MenuCommandRespondingViewController.swift in Sources */,
+				6F25F8D4269DE3BB00FA8FAB /* MenuCommandResponding.swift in Sources */,
 				C7DB4C7724806512009932B1 /* eduVPN_2.xcdatamodeld in Sources */,
 				C7DB4BFD24804C85009932B1 /* Config.swift in Sources */,
 				6FCCC577249E25F100F0F5A3 /* NavigationController.swift in Sources */,

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -280,6 +280,18 @@ protocol MenuCommandRespondingViewController {
     func actionMenuItemTitle() -> String
     func canPerformActionOnServer() -> Bool
     func performActionOnServer()
+
+    func canDeleteServer() -> Bool
+    func deleteServer()
+
+    func canToggleVPN() -> Bool
+    func toggleVPN()
+
+    func canRenewSession() -> Bool
+    func renewSession()
+
+    func canGoBackToServerList() -> Bool
+    func goBackToServerList()
 }
 
 extension AppDelegate {
@@ -298,6 +310,22 @@ extension AppDelegate {
     @IBAction func performActionOnServer(_ sender: Any?) {
         topVC?.performActionOnServer()
     }
+
+    @IBAction func deleteServer(_ sender: Any?) {
+        topVC?.deleteServer()
+    }
+
+    @IBAction func toggleVPN(_ sender: Any?) {
+        topVC?.toggleVPN()
+    }
+
+    @IBAction func renewSession(_ sender: Any?) {
+        topVC?.renewSession()
+    }
+
+    @IBAction func goBackToServerList(_ sender: Any?) {
+        topVC?.goBackToServerList()
+    }
 }
 
 extension AppDelegate: NSMenuItemValidation {
@@ -311,6 +339,14 @@ extension AppDelegate: NSMenuItemValidation {
         } else if menuItem.identifier == NSUserInterfaceItemIdentifier("performActionOnServer") {
             menuItem.title = topVC?.actionMenuItemTitle() ?? "Select"
             return topVC?.canPerformActionOnServer() ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("deleteServer") {
+            return topVC?.canDeleteServer() ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("toggleVPN") {
+            return topVC?.canToggleVPN() ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("renewSession") {
+            return topVC?.canRenewSession() ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goBackToServerList") {
+            return topVC?.canGoBackToServerList() ?? false
         }
         return true
     }

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -306,7 +306,7 @@ extension AppDelegate {
 
 extension AppDelegate: NSMenuItemValidation {
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        if menuItem.keyEquivalent == "n" {
+        if menuItem.identifier == NSUserInterfaceItemIdentifier("addNewServer") {
             return environment?.navigationController?.isToolbarLeftButtonShowsAddServerUI ?? false
         } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goNextServer") {
             return topVC?.canGoNextServer() ?? false

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -271,8 +271,8 @@ extension AppDelegate {
 }
 
 extension AppDelegate {
-    private var topVC: MenuCommandRespondingViewController? {
-        environment?.navigationController?.topViewController as? MenuCommandRespondingViewController
+    private var topVC: MenuCommandResponding? {
+        environment?.navigationController?.topViewController as? MenuCommandResponding
     }
 
     @IBAction func goNextServer(_ sender: Any?) {

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -270,54 +270,6 @@ extension AppDelegate {
     }
 }
 
-protocol MenuCommandRespondingViewController {
-    func canGoNextServer() -> Bool
-    func goNextServer()
-
-    func canGoPreviousServer() -> Bool
-    func goPreviousServer()
-
-    func actionMenuItemTitle() -> String
-    func canPerformActionOnServer() -> Bool
-    func performActionOnServer()
-
-    func canDeleteServer() -> Bool
-    func deleteServer()
-
-    func canToggleVPN() -> Bool
-    func toggleVPN()
-
-    func canActivateSelectProfilePopup() -> Bool
-    func activateSelectProfilePopup()
-
-    func canGoBackToServerList() -> Bool
-    func goBackToServerList()
-}
-
-extension MenuCommandRespondingViewController {
-    func canGoNextServer() -> Bool { return false }
-    func goNextServer() { }
-
-    func canGoPreviousServer() -> Bool { return false }
-    func goPreviousServer() { }
-
-    func actionMenuItemTitle() -> String { return "Select" }
-    func canPerformActionOnServer() -> Bool { return false }
-    func performActionOnServer() { }
-
-    func canDeleteServer() -> Bool { return false }
-    func deleteServer() { }
-
-    func canToggleVPN() -> Bool { return false }
-    func toggleVPN() { }
-
-    func canActivateSelectProfilePopup() -> Bool { return false }
-    func activateSelectProfilePopup() { }
-
-    func canGoBackToServerList() -> Bool { return false }
-    func goBackToServerList() { }
-}
-
 extension AppDelegate {
     private var topVC: MenuCommandRespondingViewController? {
         environment?.navigationController?.topViewController as? MenuCommandRespondingViewController

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -287,8 +287,8 @@ protocol MenuCommandRespondingViewController {
     func canToggleVPN() -> Bool
     func toggleVPN()
 
-    func canRenewSession() -> Bool
-    func renewSession()
+    func canActivateSelectProfilePopup() -> Bool
+    func activateSelectProfilePopup()
 
     func canGoBackToServerList() -> Bool
     func goBackToServerList()
@@ -311,8 +311,8 @@ extension MenuCommandRespondingViewController {
     func canToggleVPN() -> Bool { return false }
     func toggleVPN() { }
 
-    func canRenewSession() -> Bool { return false }
-    func renewSession() { }
+    func canActivateSelectProfilePopup() -> Bool { return false }
+    func activateSelectProfilePopup() { }
 
     func canGoBackToServerList() -> Bool { return false }
     func goBackToServerList() { }
@@ -343,8 +343,8 @@ extension AppDelegate {
         topVC?.toggleVPN()
     }
 
-    @IBAction func renewSession(_ sender: Any?) {
-        topVC?.renewSession()
+    @IBAction func activateSelectProfilePopup(_ sender: Any?) {
+        topVC?.activateSelectProfilePopup()
     }
 
     @IBAction func goBackToServerList(_ sender: Any?) {
@@ -367,8 +367,8 @@ extension AppDelegate: NSMenuItemValidation {
             return topVC?.canDeleteServer() ?? false
         } else if menuItem.identifier == NSUserInterfaceItemIdentifier("toggleVPN") {
             return topVC?.canToggleVPN() ?? false
-        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("renewSession") {
-            return topVC?.canRenewSession() ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("selectProfile") {
+            return topVC?.canActivateSelectProfilePopup() ?? false
         } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goBackToServerList") {
             return topVC?.canGoBackToServerList() ?? false
         }

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -294,6 +294,30 @@ protocol MenuCommandRespondingViewController {
     func goBackToServerList()
 }
 
+extension MenuCommandRespondingViewController {
+    func canGoNextServer() -> Bool { return false }
+    func goNextServer() { }
+
+    func canGoPreviousServer() -> Bool { return false }
+    func goPreviousServer() { }
+
+    func actionMenuItemTitle() -> String { return "Select" }
+    func canPerformActionOnServer() -> Bool { return false }
+    func performActionOnServer() { }
+
+    func canDeleteServer() -> Bool { return false }
+    func deleteServer() { }
+
+    func canToggleVPN() -> Bool { return false }
+    func toggleVPN() { }
+
+    func canRenewSession() -> Bool { return false }
+    func renewSession() { }
+
+    func canGoBackToServerList() -> Bool { return false }
+    func goBackToServerList() { }
+}
+
 extension AppDelegate {
     private var topVC: MenuCommandRespondingViewController? {
         environment?.navigationController?.topViewController as? MenuCommandRespondingViewController

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -270,10 +270,47 @@ extension AppDelegate {
     }
 }
 
+protocol MenuCommandRespondingViewController {
+    func canGoNextServer() -> Bool
+    func goNextServer()
+
+    func canGoPreviousServer() -> Bool
+    func goPreviousServer()
+
+    func actionMenuItemTitle() -> String
+    func canPerformActionOnServer() -> Bool
+    func performActionOnServer()
+}
+
+extension AppDelegate {
+    private var topVC: MenuCommandRespondingViewController? {
+        environment?.navigationController?.topViewController as? MenuCommandRespondingViewController
+    }
+
+    @IBAction func goNextServer(_ sender: Any?) {
+        topVC?.goNextServer()
+    }
+
+    @IBAction func goPreviousServer(_ sender: Any?) {
+        topVC?.goPreviousServer()
+    }
+
+    @IBAction func performActionOnServer(_ sender: Any?) {
+        topVC?.performActionOnServer()
+    }
+}
+
 extension AppDelegate: NSMenuItemValidation {
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.keyEquivalent == "n" {
             return environment?.navigationController?.isToolbarLeftButtonShowsAddServerUI ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goNextServer") {
+            return topVC?.canGoNextServer() ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goPreviousServer") {
+            return topVC?.canGoPreviousServer() ?? false
+        } else if menuItem.identifier == NSUserInterfaceItemIdentifier("performActionOnServer") {
+            menuItem.title = topVC?.actionMenuItemTitle() ?? "Select"
+            return topVC?.canPerformActionOnServer() ?? false
         }
         return true
     }

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -301,6 +301,10 @@ extension AppDelegate {
 
 extension AppDelegate: NSMenuItemValidation {
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        guard let navigationController = environment?.navigationController,
+              !navigationController.isAnimating else {
+            return false
+        }
         if menuItem.identifier == NSUserInterfaceItemIdentifier("addNewServer") {
             return topVC?.canAddNewServer() ?? false
         } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goNextServer") {

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -188,15 +188,6 @@ extension AppDelegate {
         ])
     }
 
-    @objc func newDocument(_ sender: Any) {
-        guard let navigationController = environment?.navigationController else {
-            return
-        }
-        if navigationController.isToolbarLeftButtonShowsAddServerUI {
-            navigationController.toolbarLeftButtonClicked(self)
-        }
-    }
-
     @IBAction func importOpenVPNConfig(_ sender: Any) {
         guard let mainWindow = mainWindow else { return }
         guard let persistenceService = environment?.persistenceService else { return }
@@ -275,6 +266,10 @@ extension AppDelegate {
         environment?.navigationController?.topViewController as? MenuCommandResponding
     }
 
+    @IBAction func addNewServer(_ sender: Any?) {
+        topVC?.addNewServer()
+    }
+
     @IBAction func goNextServer(_ sender: Any?) {
         topVC?.goNextServer()
     }
@@ -307,7 +302,7 @@ extension AppDelegate {
 extension AppDelegate: NSMenuItemValidation {
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.identifier == NSUserInterfaceItemIdentifier("addNewServer") {
-            return environment?.navigationController?.isToolbarLeftButtonShowsAddServerUI ?? false
+            return topVC?.canAddNewServer() ?? false
         } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goNextServer") {
             return topVC?.canGoNextServer() ?? false
         } else if menuItem.identifier == NSUserInterfaceItemIdentifier("goPreviousServer") {

--- a/EduVPN/Controllers/AddServerViewController.swift
+++ b/EduVPN/Controllers/AddServerViewController.swift
@@ -46,7 +46,7 @@ final class AddServerViewController: ViewController, ParametrizedViewController 
     var isBusy: Bool = false {
         didSet { updateIsUserAllowedToGoBack() }
     }
-    private var hasAddedServers: Bool = false {
+    private(set) var hasAddedServers: Bool = false {
         didSet { updateIsUserAllowedToGoBack() }
     }
 

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -337,6 +337,14 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
         viewModel.toggleConnectionInfoExpanded()
     }
     #endif
+
+    func canGoBack() -> Bool {
+        return parameters.environment.navigationController?.isUserAllowedToGoBack ?? false
+    }
+
+    func goBack() {
+        parameters.environment.navigationController?.popViewController(animated: true)
+    }
 }
 
 #if os(iOS)

--- a/EduVPN/Controllers/Mac/AddServerViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/AddServerViewController+macOS.swift
@@ -35,3 +35,13 @@ extension AddServerViewController: AuthorizingViewController {
         NSApp.activate(ignoringOtherApps: true)
     }
 }
+
+extension AddServerViewController: MenuCommandRespondingViewController {
+    func canGoBackToServerList() -> Bool {
+        return hasAddedServers && !isBusy
+    }
+
+    func goBackToServerList() {
+        navigationController?.popViewController(animated: true)
+    }
+}

--- a/EduVPN/Controllers/Mac/AddServerViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/AddServerViewController+macOS.swift
@@ -36,7 +36,7 @@ extension AddServerViewController: AuthorizingViewController {
     }
 }
 
-extension AddServerViewController: MenuCommandRespondingViewController {
+extension AddServerViewController: MenuCommandResponding {
     func canGoBackToServerList() -> Bool {
         return hasAddedServers && !isBusy
     }

--- a/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
@@ -1,9 +1,24 @@
 //
 //  ConnectionViewController+macOS.swift
-//  EduVPN-macOS
-//
-//  Created by Roopesh Chander S on 13/07/21.
-//  Copyright © 2021 SURFNet. All rights reserved.
-//
+//  EduVPN
 
-import Foundation
+import Cocoa
+
+extension ConnectionViewController: MenuCommandRespondingViewController {
+    func canToggleVPN() -> Bool {
+        return vpnSwitch.isEnabled
+    }
+
+    func toggleVPN() {
+        vpnSwitch.isOn = !vpnSwitch.isOn
+        vpnSwitchToggled()
+    }
+
+    func canGoBackToServerList() -> Bool {
+        return canGoBack()
+    }
+
+    func goBackToServerList() {
+        goBack()
+    }
+}

--- a/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
@@ -1,0 +1,9 @@
+//
+//  ConnectionViewController+macOS.swift
+//  EduVPN-macOS
+//
+//  Created by Roopesh Chander S on 13/07/21.
+//  Copyright © 2021 SURFNet. All rights reserved.
+//
+
+import Foundation

--- a/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
@@ -14,6 +14,17 @@ extension ConnectionViewController: MenuCommandRespondingViewController {
         vpnSwitchToggled()
     }
 
+    func canActivateSelectProfilePopup() -> Bool {
+        return !profileSelectionView.isHidden
+    }
+
+    func activateSelectProfilePopup() {
+        if !profileSelectionView.isHidden {
+            (NSApp.delegate as? AppDelegate)?.showMainWindow(self)
+            profileSelectorPopupButton.performClick(self)
+        }
+    }
+
     func canGoBackToServerList() -> Bool {
         return canGoBack()
     }

--- a/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/ConnectionViewController+macOS.swift
@@ -4,7 +4,7 @@
 
 import Cocoa
 
-extension ConnectionViewController: MenuCommandRespondingViewController {
+extension ConnectionViewController: MenuCommandResponding {
     func canToggleVPN() -> Bool {
         return vpnSwitch.isEnabled
     }

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -118,4 +118,68 @@ extension MainViewController: MenuCommandRespondingViewController {
             tableView.selectRowIndexes([], byExtendingSelection: false)
         }
     }
+
+    func canDeleteServer() -> Bool {
+        let currentRow = tableView.selectedRow
+        guard currentRow >= 0 && currentRow < numberOfRows() else {
+            return false
+        }
+        return canDeleteRow(at: currentRow)
+    }
+
+    func deleteServer() {
+        let currentRow = tableView.selectedRow
+        guard currentRow >= 0 && currentRow < numberOfRows() else {
+            return
+        }
+        if canDeleteRow(at: currentRow) {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = NSLocalizedString(
+                "Are you sure you want to delete server “\(displayText(at: currentRow))”?",
+                comment: "macOS alert title to confirm deletion of added server from menu")
+            alert.addButton(withTitle: NSLocalizedString(
+                                "Delete",
+                                comment: "macOS alert button to confirm deletion of added server from menu"))
+            alert.addButton(withTitle: NSLocalizedString(
+                                "Cancel",
+                                comment: "macOS alert button to confirm deletion of added server from menu"))
+            if let window = NSApp.windows.first {
+                alert.beginSheetModal(for: window) { result in
+                    if case .alertFirstButtonReturn = result {
+                        self.deleteRow(at: currentRow)
+                    }
+                }
+            } else {
+                let result = alert.runModal()
+                if case .alertFirstButtonReturn = result {
+                    self.deleteRow(at: currentRow)
+                }
+            }
+        }
+    }
+
+    func canToggleVPN() -> Bool {
+        return false
+    }
+
+    func toggleVPN() {
+        // Can't toggle VPN while in main screen
+    }
+
+    func canRenewSession() -> Bool {
+        return false
+    }
+
+    func renewSession() {
+        // Can't renew session while in main screen
+    }
+
+    func canGoBackToServerList() -> Bool {
+        return false
+    }
+
+    func goBackToServerList() {
+        // Can't go back to server list while in main screen
+    }
 }

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -64,6 +64,14 @@ extension MainViewController {
 }
 
 extension MainViewController: MenuCommandResponding {
+    func canAddNewServer() -> Bool {
+        return true
+    }
+
+    func addNewServer() {
+        showSearchVCOrAddServerVC()
+    }
+
     func canGoNextServer() -> Bool {
         guard tableView.selectedRow >= 0 else {
             return numberOfRows() > 0

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -158,28 +158,4 @@ extension MainViewController: MenuCommandRespondingViewController {
             }
         }
     }
-
-    func canToggleVPN() -> Bool {
-        return false
-    }
-
-    func toggleVPN() {
-        // Can't toggle VPN while in main screen
-    }
-
-    func canRenewSession() -> Bool {
-        return false
-    }
-
-    func renewSession() {
-        // Can't renew session while in main screen
-    }
-
-    func canGoBackToServerList() -> Bool {
-        return false
-    }
-
-    func goBackToServerList() {
-        // Can't go back to server list while in main screen
-    }
 }

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -79,6 +79,7 @@ extension MainViewController: MenuCommandRespondingViewController {
         if canSelectRow(at: currentRow) {
             shouldPerformActionOnSelection = false
             tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            tableView.scrollRowToVisible(currentRow)
             shouldPerformActionOnSelection = true
         }
     }
@@ -98,6 +99,7 @@ extension MainViewController: MenuCommandRespondingViewController {
         if canSelectRow(at: currentRow) {
             shouldPerformActionOnSelection = false
             tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            tableView.scrollRowToVisible(currentRow)
             shouldPerformActionOnSelection = true
         }
     }

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -65,12 +65,15 @@ extension MainViewController {
 
 extension MainViewController: MenuCommandRespondingViewController {
     func canGoNextServer() -> Bool {
-        tableView.selectedRow < (numberOfRows() - 1)
+        guard tableView.selectedRow >= 0 else {
+            return numberOfRows() > 0
+        }
+        return tableView.selectedRow < (numberOfRows() - 1)
     }
 
     func goNextServer() {
         var currentRow = tableView.selectedRow + 1
-        while !canSelectRow(at: currentRow) && currentRow < numberOfRows() {
+        while currentRow < numberOfRows() && !canSelectRow(at: currentRow) {
             currentRow += 1
         }
         if canSelectRow(at: currentRow) {
@@ -81,7 +84,10 @@ extension MainViewController: MenuCommandRespondingViewController {
     }
 
     func canGoPreviousServer() -> Bool {
-        tableView.selectedRow > 1 || canSelectRow(at: 0)
+        guard tableView.selectedRow > 0 else {
+            return false
+        }
+        return tableView.selectedRow > 1 || canSelectRow(at: tableView.selectedRow - 1)
     }
 
     func goPreviousServer() {

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -20,6 +20,7 @@ extension MainViewController: NSTableViewDelegate, NSTableViewDataSource {
 
     func tableViewSelectionDidChange(_ notification: Notification) {
         guard let tableView = notification.object as? NSTableView else { return }
+        guard shouldPerformActionOnSelection else { return }
         if let firstSelectedIndex = tableView.selectedRowIndexes.first {
             didSelectRow(at: firstSelectedIndex)
         }
@@ -59,5 +60,62 @@ extension MainViewController {
     @objc func deleteMenuItemClicked(_ sender: Any) {
         let index = tableView.clickedRow
         self.deleteRow(at: index)
+    }
+}
+
+extension MainViewController: MenuCommandRespondingViewController {
+    func canGoNextServer() -> Bool {
+        tableView.selectedRow < (numberOfRows() - 1)
+    }
+
+    func goNextServer() {
+        var currentRow = tableView.selectedRow + 1
+        while !canSelectRow(at: currentRow) && currentRow < numberOfRows() {
+            currentRow += 1
+        }
+        if canSelectRow(at: currentRow) {
+            shouldPerformActionOnSelection = false
+            tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            shouldPerformActionOnSelection = true
+        }
+    }
+
+    func canGoPreviousServer() -> Bool {
+        tableView.selectedRow > 1 || canSelectRow(at: 0)
+    }
+
+    func goPreviousServer() {
+        var currentRow = tableView.selectedRow - 1
+        while !canSelectRow(at: currentRow) && currentRow >= 0 {
+            currentRow -= 1
+        }
+        if canSelectRow(at: currentRow) {
+            shouldPerformActionOnSelection = false
+            tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            shouldPerformActionOnSelection = true
+        }
+    }
+
+    func actionMenuItemTitle() -> String {
+        return "Begin Connecting"
+    }
+
+    func canPerformActionOnServer() -> Bool {
+        let currentRow = tableView.selectedRow
+        guard currentRow >= 0 && currentRow < numberOfRows() else {
+            return false
+        }
+        return canSelectRow(at: tableView.selectedRow)
+    }
+
+    func performActionOnServer() {
+        let currentRow = tableView.selectedRow
+        guard currentRow >= 0 && currentRow < numberOfRows() else {
+            return
+        }
+        if canSelectRow(at: currentRow) {
+            didSelectRow(at: currentRow)
+            tableView.selectRowIndexes([], byExtendingSelection: false)
+        }
     }
 }

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -63,7 +63,7 @@ extension MainViewController {
     }
 }
 
-extension MainViewController: MenuCommandRespondingViewController {
+extension MainViewController: MenuCommandResponding {
     func canGoNextServer() -> Bool {
         guard tableView.selectedRow >= 0 else {
             return numberOfRows() > 0

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -63,6 +63,17 @@ extension MainViewController {
     }
 }
 
+extension MainViewController {
+    @objc func onTableClicked() {
+        // If a row is already selected by keyboard, and the user clicks on it,
+        // we should perform the action on the row even if it's already selected.
+        if tableView.clickedRow >= 0 && tableView.selectedRow == tableView.clickedRow {
+            didSelectRow(at: tableView.selectedRow)
+            tableView.selectRowIndexes([], byExtendingSelection: false)
+        }
+    }
+}
+
 extension MainViewController: MenuCommandResponding {
     func canAddNewServer() -> Bool {
         return true

--- a/EduVPN/Controllers/Mac/MainViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+macOS.swift
@@ -124,7 +124,7 @@ extension MainViewController: MenuCommandResponding {
     }
 
     func actionMenuItemTitle() -> String {
-        return "Begin Connecting"
+        return "Connect..."
     }
 
     func canPerformActionOnServer() -> Bool {

--- a/EduVPN/Controllers/Mac/MenuCommandResponding.swift
+++ b/EduVPN/Controllers/Mac/MenuCommandResponding.swift
@@ -7,6 +7,9 @@
 import Cocoa
 
 protocol MenuCommandResponding {
+    func canAddNewServer() -> Bool
+    func addNewServer()
+
     func canGoNextServer() -> Bool
     func goNextServer()
 
@@ -31,6 +34,9 @@ protocol MenuCommandResponding {
 }
 
 extension MenuCommandResponding {
+    func canAddNewServer() -> Bool { return false }
+    func addNewServer() { }
+
     func canGoNextServer() -> Bool { return false }
     func goNextServer() { }
 

--- a/EduVPN/Controllers/Mac/MenuCommandResponding.swift
+++ b/EduVPN/Controllers/Mac/MenuCommandResponding.swift
@@ -1,12 +1,12 @@
 //
-//  MenuCommandRespondingViewController.swift
+//  MenuCommandResponding.swift
 //  EduVPN
 
 //  Protocol representing the commands in the 'Server' app menu
 
 import Cocoa
 
-protocol MenuCommandRespondingViewController {
+protocol MenuCommandResponding {
     func canGoNextServer() -> Bool
     func goNextServer()
 
@@ -30,7 +30,7 @@ protocol MenuCommandRespondingViewController {
     func goBackToServerList()
 }
 
-extension MenuCommandRespondingViewController {
+extension MenuCommandResponding {
     func canGoNextServer() -> Bool { return false }
     func goNextServer() { }
 

--- a/EduVPN/Controllers/Mac/MenuCommandRespondingViewController.swift
+++ b/EduVPN/Controllers/Mac/MenuCommandRespondingViewController.swift
@@ -1,0 +1,55 @@
+//
+//  MenuCommandRespondingViewController.swift
+//  EduVPN
+
+//  Protocol representing the commands in the 'Server' app menu
+
+import Cocoa
+
+protocol MenuCommandRespondingViewController {
+    func canGoNextServer() -> Bool
+    func goNextServer()
+
+    func canGoPreviousServer() -> Bool
+    func goPreviousServer()
+
+    func actionMenuItemTitle() -> String
+    func canPerformActionOnServer() -> Bool
+    func performActionOnServer()
+
+    func canDeleteServer() -> Bool
+    func deleteServer()
+
+    func canToggleVPN() -> Bool
+    func toggleVPN()
+
+    func canActivateSelectProfilePopup() -> Bool
+    func activateSelectProfilePopup()
+
+    func canGoBackToServerList() -> Bool
+    func goBackToServerList()
+}
+
+extension MenuCommandRespondingViewController {
+    func canGoNextServer() -> Bool { return false }
+    func goNextServer() { }
+
+    func canGoPreviousServer() -> Bool { return false }
+    func goPreviousServer() { }
+
+    func actionMenuItemTitle() -> String { return "Select" }
+    func canPerformActionOnServer() -> Bool { return false }
+    func performActionOnServer() { }
+
+    func canDeleteServer() -> Bool { return false }
+    func deleteServer() { }
+
+    func canToggleVPN() -> Bool { return false }
+    func toggleVPN() { }
+
+    func canActivateSelectProfilePopup() -> Bool { return false }
+    func activateSelectProfilePopup() { }
+
+    func canGoBackToServerList() -> Bool { return false }
+    func goBackToServerList() { }
+}

--- a/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
@@ -84,8 +84,13 @@ extension SearchViewController: AuthorizingViewController {
 
 extension SearchViewController: MenuCommandRespondingViewController {
     func canGoNextServer() -> Bool {
-        let rowCount = numberOfRows()
-        return hasResults() && rowCount > 0 && tableView.selectedRow < (rowCount - 1)
+        guard hasResults() else {
+            return false
+        }
+        guard tableView.selectedRow >= 0 else {
+            return numberOfRows() > 0
+        }
+        return tableView.selectedRow < (numberOfRows() - 1)
     }
 
     func goNextServer() {
@@ -101,7 +106,10 @@ extension SearchViewController: MenuCommandRespondingViewController {
     }
 
     func canGoPreviousServer() -> Bool {
-        tableView.selectedRow > 1 || canSelectRow(at: 0)
+        guard hasResults() && tableView.selectedRow > 0 else {
+            return false
+        }
+        return tableView.selectedRow > 1 || canSelectRow(at: tableView.selectedRow - 1)
     }
 
     func goPreviousServer() {

--- a/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
@@ -139,30 +139,6 @@ extension SearchViewController: MenuCommandRespondingViewController {
         }
     }
 
-    func canDeleteServer() -> Bool {
-        return false
-    }
-
-    func deleteServer() {
-        // Can't delete server while in Search screen
-    }
-
-    func canToggleVPN() -> Bool {
-        return false
-    }
-
-    func toggleVPN() {
-        // Can't toggle VPN while in main screen
-    }
-
-    func canRenewSession() -> Bool {
-        return false
-    }
-
-    func renewSession() {
-        // Can't renew session while in main screen
-    }
-
     func canGoBackToServerList() -> Bool {
         return hasAddedServers && !isBusy
     }

--- a/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
@@ -20,6 +20,7 @@ extension SearchViewController: NSTableViewDelegate, NSTableViewDataSource {
 
     func tableViewSelectionDidChange(_ notification: Notification) {
         guard let tableView = notification.object as? NSTableView else { return }
+        guard shouldPerformActionOnSelection else { return }
         if let firstSelectedIndex = tableView.selectedRowIndexes.first {
             didSelectRow(at: firstSelectedIndex)
         }
@@ -78,5 +79,95 @@ extension SearchViewController: AuthorizingViewController {
     func didEndAuthorization() {
         navigationController?.hideAuthorizingMessage()
         NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+extension SearchViewController: MenuCommandRespondingViewController {
+    func canGoNextServer() -> Bool {
+        let rowCount = numberOfRows()
+        return hasResults() && rowCount > 0 && tableView.selectedRow < (rowCount - 1)
+    }
+
+    func goNextServer() {
+        var currentRow = tableView.selectedRow + 1
+        while currentRow < numberOfRows() && !canSelectRow(at: currentRow) {
+            currentRow += 1
+        }
+        if canSelectRow(at: currentRow) {
+            shouldPerformActionOnSelection = false
+            tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            shouldPerformActionOnSelection = true
+        }
+    }
+
+    func canGoPreviousServer() -> Bool {
+        tableView.selectedRow > 1 || canSelectRow(at: 0)
+    }
+
+    func goPreviousServer() {
+        var currentRow = tableView.selectedRow - 1
+        while !canSelectRow(at: currentRow) && currentRow >= 0 {
+            currentRow -= 1
+        }
+        if canSelectRow(at: currentRow) {
+            shouldPerformActionOnSelection = false
+            tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            shouldPerformActionOnSelection = true
+        }
+    }
+
+    func actionMenuItemTitle() -> String {
+        return "Add Server..."
+    }
+
+    func canPerformActionOnServer() -> Bool {
+        let currentRow = tableView.selectedRow
+        guard currentRow >= 0 && currentRow < numberOfRows() else {
+            return false
+        }
+        return canSelectRow(at: tableView.selectedRow)
+    }
+
+    func performActionOnServer() {
+        let currentRow = tableView.selectedRow
+        guard currentRow >= 0 && currentRow < numberOfRows() else {
+            return
+        }
+        if canSelectRow(at: currentRow) {
+            didSelectRow(at: currentRow)
+            tableView.selectRowIndexes([], byExtendingSelection: false)
+        }
+    }
+
+    func canDeleteServer() -> Bool {
+        return false
+    }
+
+    func deleteServer() {
+        // Can't delete server while in Search screen
+    }
+
+    func canToggleVPN() -> Bool {
+        return false
+    }
+
+    func toggleVPN() {
+        // Can't toggle VPN while in main screen
+    }
+
+    func canRenewSession() -> Bool {
+        return false
+    }
+
+    func renewSession() {
+        // Can't renew session while in main screen
+    }
+
+    func canGoBackToServerList() -> Bool {
+        return hasAddedServers && !isBusy
+    }
+
+    func goBackToServerList() {
+        navigationController?.popViewController(animated: true)
     }
 }

--- a/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
@@ -82,7 +82,7 @@ extension SearchViewController: AuthorizingViewController {
     }
 }
 
-extension SearchViewController: MenuCommandRespondingViewController {
+extension SearchViewController: MenuCommandResponding {
     func canGoNextServer() -> Bool {
         guard hasResults() else {
             return false

--- a/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
@@ -82,6 +82,17 @@ extension SearchViewController: AuthorizingViewController {
     }
 }
 
+extension SearchViewController {
+    @objc func onTableClicked() {
+        // If a row is already selected by keyboard, and the user clicks on it,
+        // we should perform the action on the row even if it's already selected.
+        if tableView.clickedRow >= 0 && tableView.selectedRow == tableView.clickedRow {
+            didSelectRow(at: tableView.selectedRow)
+            tableView.selectRowIndexes([], byExtendingSelection: false)
+        }
+    }
+}
+
 extension SearchViewController: MenuCommandResponding {
     func canGoNextServer() -> Bool {
         guard hasResults() else {

--- a/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
+++ b/EduVPN/Controllers/Mac/SearchViewController+macOS.swift
@@ -101,6 +101,7 @@ extension SearchViewController: MenuCommandRespondingViewController {
         if canSelectRow(at: currentRow) {
             shouldPerformActionOnSelection = false
             tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            tableView.scrollRowToVisible(currentRow)
             shouldPerformActionOnSelection = true
         }
     }
@@ -120,6 +121,7 @@ extension SearchViewController: MenuCommandRespondingViewController {
         if canSelectRow(at: currentRow) {
             shouldPerformActionOnSelection = false
             tableView.selectRowIndexes([currentRow], byExtendingSelection: false)
+            tableView.scrollRowToVisible(currentRow)
             shouldPerformActionOnSelection = true
         }
     }

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -91,6 +91,8 @@ class MainViewController: ViewController {
     #if os(macOS)
     override func viewDidLoad() {
         tableView.refusesFirstResponder = true
+        tableView.action = #selector(onTableClicked)
+        tableView.target = self
     }
     #endif
 

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -64,6 +64,10 @@ class MainViewController: ViewController {
     // swiftlint:disable:next identifier_name
     private var shouldRenewSessionWhenConnectionServiceInitialized = false
 
+    #if os(macOS)
+    var shouldPerformActionOnSelection = true
+    #endif
+
     @IBOutlet weak var tableView: TableView!
 
     #if os(iOS)

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -134,6 +134,10 @@ class MainViewController: ViewController {
 
 extension MainViewController: NavigationControllerAddButtonDelegate {
     func addButtonClicked(inNavigationController controller: NavigationController) {
+        showSearchVCOrAddServerVC()
+    }
+
+    func showSearchVCOrAddServerVC() {
         if Config.shared.apiDiscoveryEnabled ?? false {
             let isSecureInternetServerAdded = (environment.persistenceService.secureInternetServer != nil)
             let searchVC = environment.instantiateSearchViewController(

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -84,6 +84,12 @@ class MainViewController: ViewController {
     }
     #endif
 
+    #if os(macOS)
+    override func viewDidLoad() {
+        tableView.refusesFirstResponder = true
+    }
+    #endif
+
     func refresh() {
         viewModel.update()
     }

--- a/EduVPN/Controllers/SearchViewController.swift
+++ b/EduVPN/Controllers/SearchViewController.swift
@@ -89,6 +89,10 @@ final class SearchViewController: ViewController, ParametrizedViewController {
         if shouldAutoFocusSearchField {
             showTableView(animated: false)
         }
+
+        #if os(macOS)
+        tableView.refusesFirstResponder = true
+        #endif
     }
 
     #if os(macOS)

--- a/EduVPN/Controllers/SearchViewController.swift
+++ b/EduVPN/Controllers/SearchViewController.swift
@@ -49,12 +49,13 @@ final class SearchViewController: ViewController, ParametrizedViewController {
     var isBusy: Bool = false {
         didSet { updateIsUserAllowedToGoBack() }
     }
-    private var hasAddedServers: Bool = false {
+    private(set) var hasAddedServers: Bool = false {
         didSet { updateIsUserAllowedToGoBack() }
     }
 
     #if os(macOS)
     var navigationController: NavigationController? { parameters.environment.navigationController }
+    var shouldPerformActionOnSelection = true
     #endif
 
     #if os(iOS)
@@ -174,6 +175,10 @@ extension SearchViewController {
 // MARK: - Table view delegate and data source
 
 extension SearchViewController {
+    func hasResults() -> Bool {
+        return viewModel?.hasResults() ?? false
+    }
+
     func numberOfRows() -> Int {
         return viewModel?.numberOfRows() ?? 0
     }

--- a/EduVPN/Controllers/SearchViewController.swift
+++ b/EduVPN/Controllers/SearchViewController.swift
@@ -93,6 +93,8 @@ final class SearchViewController: ViewController, ParametrizedViewController {
 
         #if os(macOS)
         tableView.refusesFirstResponder = true
+        tableView.action = #selector(onTableClicked)
+        tableView.target = self
         #endif
     }
 

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -65,9 +65,9 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="File" id="bib-Uj-vzu">
                                     <items>
-                                        <menuItem title="Add New Server..." keyEquivalent="n" id="Was-JA-tGl">
+                                        <menuItem title="Add New Server..." keyEquivalent="n" identifier="addNewServer" id="Was-JA-tGl">
                                             <connections>
-                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                                <action selector="addNewServer:" target="Voe-Tx-rLC" id="G2t-JK-4xW"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Import OpenVPN Configuration..." keyEquivalent="i" id="9SY-An-WWD">

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -336,9 +336,9 @@ CA
                                                 <action selector="toggleVPN:" target="Voe-Tx-rLC" id="eop-IN-iIn"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Renew Session..." keyEquivalent="r" identifier="renewSession" id="oxX-8B-iYR">
+                                        <menuItem title="Select Profile..." keyEquivalent="p" identifier="selectProfile" id="oxX-8B-iYR">
                                             <connections>
-                                                <action selector="renewSession:" target="Voe-Tx-rLC" id="lRh-J3-314"/>
+                                                <action selector="activateSelectProfilePopup:" target="Voe-Tx-rLC" id="3hv-Ri-ZRA"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="9z1-kA-xmY"/>
@@ -584,13 +584,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2356" height="59"/>
+                                <rect key="frame" x="20" y="20" width="2390" height="39"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2356" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2390" height="39"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2356" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2390" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -306,24 +306,24 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Server" id="NGK-kD-c0a">
                                     <items>
-                                        <menuItem title="Next" keyEquivalent="" id="fEQ-K3-WAW">
+                                        <menuItem title="Next" keyEquivalent="" identifier="goNextServer" id="fEQ-K3-WAW">
                                             <connections>
-                                                <action selector="newDocument:" target="Ady-hI-5gd" id="pGU-me-Z2a"/>
+                                                <action selector="goNextServer:" target="Voe-Tx-rLC" id="F79-zG-dkb"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Previous" keyEquivalent="" id="jRF-Ty-dfT">
+                                        <menuItem title="Previous" keyEquivalent="" identifier="goPreviousServer" id="jRF-Ty-dfT">
                                             <connections>
-                                                <action selector="newDocument:" target="Ady-hI-5gd" id="ife-BU-hLa"/>
+                                                <action selector="goPreviousServer:" target="Voe-Tx-rLC" id="GsQ-l3-WAN"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="if5-e0-2yS"/>
-                                        <menuItem title="Select..." id="FkG-3m-e4e">
+                                        <menuItem title="Select..." identifier="performActionOnServer" id="FkG-3m-e4e">
                                             <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="importOpenVPNConfig:" target="Voe-Tx-rLC" id="qrW-xe-Evr"/>
+                                                <action selector="performActionOnServer:" target="Voe-Tx-rLC" id="M2k-Ps-xgD"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Delete" id="e2B-cp-wUS">
@@ -588,13 +588,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2186" height="14"/>
+                                <rect key="frame" x="20" y="20" width="2254" height="12"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2186" height="14"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2254" height="12"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2186" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2254" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -823,11 +823,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="246" width="90" height="560"/>
+                                        <rect key="frame" x="195" y="274" width="90" height="532"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="201" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="229" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -835,7 +835,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="149" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="177" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -849,12 +849,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="105" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="133" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="5" y="0.0" width="470" height="93"/>
+                                        <rect key="frame" x="5" y="0.0" width="470" height="121"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="470" height="93"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="470" height="121"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">
@@ -968,7 +968,7 @@ Gw
                                             <nil key="backgroundColor"/>
                                         </clipView>
                                         <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Qqv-vd-gvO">
-                                            <rect key="frame" x="1" y="119" width="223" height="15"/>
+                                            <rect key="frame" x="0.0" y="71" width="470" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="kUF-MN-H8o">
@@ -2410,7 +2410,7 @@ Gw
         <image name="SearchScreenTopImage" width="90" height="79.5"/>
         <image name="SettingsButton" width="20" height="20"/>
         <image name="SettingsButtonSelected" width="20" height="20"/>
-        <image name="TopBarLogo" width="440" height="130"/>
+        <image name="TopBarLogo" width="135.5" height="40"/>
         <image name="buttonCell:any-W4-2O1:alternateImage" width="70" height="30">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -65,7 +65,7 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="File" id="bib-Uj-vzu">
                                     <items>
-                                        <menuItem title="Add Server..." keyEquivalent="n" id="Was-JA-tGl">
+                                        <menuItem title="Add New Server..." keyEquivalent="n" id="Was-JA-tGl">
                                             <connections>
                                                 <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
                                             </connections>

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -317,11 +317,7 @@
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="if5-e0-2yS"/>
-                                        <menuItem title="Select..." identifier="performActionOnServer" id="FkG-3m-e4e">
-                                            <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                        <menuItem title="Select..." keyEquivalent="" identifier="performActionOnServer" id="FkG-3m-e4e">
                                             <connections>
                                                 <action selector="performActionOnServer:" target="Voe-Tx-rLC" id="M2k-Ps-xgD"/>
                                             </connections>
@@ -424,7 +420,7 @@ CA
                                 <rect key="frame" x="10" y="520" width="400" height="60"/>
                                 <subviews>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="PNs-Y1-pKE" userLabel="Toolbar Logo View">
-                                        <rect key="frame" x="-20" y="12" width="440" height="40"/>
+                                        <rect key="frame" x="133" y="12" width="135" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="R6d-kC-jEw"/>
                                         </constraints>
@@ -588,13 +584,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2254" height="12"/>
+                                <rect key="frame" x="20" y="20" width="2305" height="45"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2254" height="12"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2305" height="45"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2254" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2305" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -823,11 +819,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="274" width="90" height="532"/>
+                                        <rect key="frame" x="195" y="347" width="90" height="459"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="229" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="302" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -835,7 +831,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="177" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="250" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -849,12 +845,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="133" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="206" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="5" y="0.0" width="470" height="121"/>
+                                        <rect key="frame" x="5" y="0.0" width="470" height="194"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="470" height="121"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="470" height="194"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">
@@ -968,7 +964,7 @@ Gw
                                             <nil key="backgroundColor"/>
                                         </clipView>
                                         <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Qqv-vd-gvO">
-                                            <rect key="frame" x="0.0" y="71" width="470" height="16"/>
+                                            <rect key="frame" x="0.0" y="178" width="470" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="kUF-MN-H8o">
@@ -25340,7 +25336,7 @@ ABDl3AAQ5eEAEOXpAAAAAAAABAEAAAAAAAAAaAAAAAAAAAAAAAAAAAAQ5ew
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="RegularUITextColor">
-            <color red="0.31372549019607843" green="0.31372549019607843" blue="0.31372549019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.31400001049041748" green="0.31400001049041748" blue="0.31400001049041748" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -420,7 +420,7 @@ CA
                                 <rect key="frame" x="10" y="520" width="400" height="60"/>
                                 <subviews>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="PNs-Y1-pKE" userLabel="Toolbar Logo View">
-                                        <rect key="frame" x="133" y="12" width="135" height="40"/>
+                                        <rect key="frame" x="132" y="12" width="136" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="R6d-kC-jEw"/>
                                         </constraints>
@@ -584,13 +584,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2390" height="39"/>
+                                <rect key="frame" x="20" y="20" width="2424" height="19"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2390" height="39"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2424" height="19"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2390" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2424" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -819,11 +819,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="347" width="90" height="459"/>
+                                        <rect key="frame" x="195" y="327" width="90" height="479"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="302" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="282" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -831,7 +831,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="250" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="230" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -845,12 +845,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="206" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="186" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="5" y="0.0" width="470" height="194"/>
+                                        <rect key="frame" x="5" y="0.0" width="470" height="174"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="470" height="194"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="470" height="174"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -302,6 +302,58 @@
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Server" id="09Y-Xg-G3X" userLabel="Server">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Server" id="NGK-kD-c0a">
+                                    <items>
+                                        <menuItem title="Next" keyEquivalent="" id="fEQ-K3-WAW">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="pGU-me-Z2a"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Previous" keyEquivalent="" id="jRF-Ty-dfT">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="ife-BU-hLa"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="if5-e0-2yS"/>
+                                        <menuItem title="Select..." id="FkG-3m-e4e">
+                                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="importOpenVPNConfig:" target="Voe-Tx-rLC" id="qrW-xe-Evr"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="e2B-cp-wUS">
+                                            <string key="keyEquivalent" base64-UTF8="YES">
+CA
+</string>
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="DRC-fY-apF"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hyf-BU-h6f"/>
+                                        <menuItem title="Toggle VPN" keyEquivalent="t" id="2ss-1Q-5OP">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="hTL-gc-TaB"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Renew Session..." keyEquivalent="r" id="oxX-8B-iYR">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="mDO-ar-6VK"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="9z1-kA-xmY"/>
+                                        <menuItem title="Go Back to Server List" keyEquivalent="" id="ytV-Db-jDo">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="x1x-GH-KFp"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Window" id="aUF-d1-5bR">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
@@ -536,13 +588,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2152" height="15"/>
+                                <rect key="frame" x="20" y="20" width="2186" height="14"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2152" height="15"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2186" height="14"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2152" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2186" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -771,11 +823,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="266" width="90" height="540"/>
+                                        <rect key="frame" x="195" y="246" width="90" height="560"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="221" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="201" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -783,7 +835,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="169" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="149" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -797,12 +849,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="125" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="105" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="5" y="0.0" width="470" height="113"/>
+                                        <rect key="frame" x="5" y="0.0" width="470" height="93"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="470" height="113"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="470" height="93"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -322,29 +322,29 @@
                                                 <action selector="performActionOnServer:" target="Voe-Tx-rLC" id="M2k-Ps-xgD"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Delete" id="e2B-cp-wUS">
+                                        <menuItem title="Delete" identifier="deleteServer" id="e2B-cp-wUS">
                                             <string key="keyEquivalent" base64-UTF8="YES">
 CA
 </string>
                                             <connections>
-                                                <action selector="performClose:" target="Ady-hI-5gd" id="DRC-fY-apF"/>
+                                                <action selector="deleteServer:" target="Voe-Tx-rLC" id="AJw-wJ-Vn2"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="hyf-BU-h6f"/>
-                                        <menuItem title="Toggle VPN" keyEquivalent="t" id="2ss-1Q-5OP">
+                                        <menuItem title="Toggle VPN" keyEquivalent="t" identifier="toggleVPN" id="2ss-1Q-5OP">
                                             <connections>
-                                                <action selector="performClose:" target="Ady-hI-5gd" id="hTL-gc-TaB"/>
+                                                <action selector="toggleVPN:" target="Voe-Tx-rLC" id="eop-IN-iIn"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Renew Session..." keyEquivalent="r" id="oxX-8B-iYR">
+                                        <menuItem title="Renew Session..." keyEquivalent="r" identifier="renewSession" id="oxX-8B-iYR">
                                             <connections>
-                                                <action selector="performClose:" target="Ady-hI-5gd" id="mDO-ar-6VK"/>
+                                                <action selector="renewSession:" target="Voe-Tx-rLC" id="lRh-J3-314"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="9z1-kA-xmY"/>
-                                        <menuItem title="Go Back to Server List" keyEquivalent="" id="ytV-Db-jDo">
+                                        <menuItem title="Go Back to Server List" keyEquivalent="" identifier="goBackToServerList" id="ytV-Db-jDo">
                                             <connections>
-                                                <action selector="performClose:" target="Ady-hI-5gd" id="x1x-GH-KFp"/>
+                                                <action selector="goBackToServerList:" target="Voe-Tx-rLC" id="cOB-GQ-sL7"/>
                                             </connections>
                                         </menuItem>
                                     </items>
@@ -584,13 +584,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2305" height="45"/>
+                                <rect key="frame" x="20" y="20" width="2356" height="59"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2305" height="45"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2356" height="59"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2305" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2356" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -336,7 +336,7 @@ CA
                                                 <action selector="toggleVPN:" target="Voe-Tx-rLC" id="eop-IN-iIn"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Select Profile..." keyEquivalent="p" identifier="selectProfile" id="oxX-8B-iYR">
+                                        <menuItem title="Select Profile..." keyEquivalent="l" identifier="selectProfile" id="oxX-8B-iYR">
                                             <connections>
                                                 <action selector="activateSelectProfilePopup:" target="Voe-Tx-rLC" id="3hv-Ri-ZRA"/>
                                             </connections>

--- a/EduVPN/Shims/NavigationController.swift
+++ b/EduVPN/Shims/NavigationController.swift
@@ -22,6 +22,11 @@ class NavigationController: NSViewController {
 
     var isToolbarLeftButtonShowsAddServerUI: Bool { !canGoBack }
     var topViewController: ViewController? { children.last }
+    private(set) var isAnimating: Bool = false {
+        didSet {
+            toolbarLeftButton.isEnabled = !isAnimating
+        }
+    }
 
     weak var addButtonDelegate: NavigationControllerAddButtonDelegate?
 
@@ -89,12 +94,12 @@ extension NavigationController: Navigating {
         guard let lastVC = children.last else { return }
 
         addChild(viewController)
-        toolbarLeftButton.isEnabled = false
+        isAnimating = true
         transition(from: lastVC, to: viewController,
                    options: animated ? .slideForward : []) { [weak self] in
             guard let self = self else { return }
             self.updateToolbarLeftButton()
-            self.toolbarLeftButton.isEnabled = true
+            self.isAnimating = false
         }
     }
 
@@ -104,14 +109,14 @@ extension NavigationController: Navigating {
         let lastVC = children[children.count - 1]
         let lastButOneVC = children[children.count - 2]
 
-        toolbarLeftButton.isEnabled = false
+        isAnimating = true
         transition(from: lastVC, to: lastButOneVC,
                    options: animated ? .slideBackward : []) { [weak self] in
             guard let self = self else { return }
             lastVC.removeFromParent()
             self.isUserAllowedToGoBack = true
             self.updateToolbarLeftButton()
-            self.toolbarLeftButton.isEnabled = true
+            self.isAnimating = false
         }
 
         return lastVC

--- a/EduVPN/ViewModels/SearchViewModel.swift
+++ b/EduVPN/ViewModels/SearchViewModel.swift
@@ -159,6 +159,10 @@ class SearchViewModel {
         }
         return nil
     }
+
+    func hasResults() -> Bool {
+        return !rows.isEmpty && row(at: 0) != .noResults
+    }
 }
 
 private extension SearchViewModel {


### PR DESCRIPTION
Adresses #331.

This PR:
  - Disables default keyboard handling in `NSTableView`s in main screen and search screen
  - Introduces a 'Server' app menu with menu items for navigating the server list and selecting a server. It also has menu items for selecting profiles and toggling the VPN, but those are applicable only when in the connection screen.

The menus in each screen look like this:
  - Main screen:
    <img width="288" alt="when_in_main_screen" src="https://user-images.githubusercontent.com/554/125509289-b0f0525e-fd29-4710-a428-e8b784ee25dc.png">
  - Search screen:
    <img width="287" alt="when_in_search_screen" src="https://user-images.githubusercontent.com/554/125509331-2b506b72-7951-4dda-aa09-7b28f4603cdd.png">
  - Connection screen: 
    <img width="304" alt="when_in_connection_screen" src="https://user-images.githubusercontent.com/554/125509369-988ea1c4-822b-4d04-80ed-6f3648771756.png">


Why:

  - When in the search screen, we want the search field to have the focus all the time, so that the user can type-to-search anytime. Therefore, we can't have the tableview getting focus and receiving key events. So, we can't make use of the search screen tableview's default keyboard handling.
  - The app menu is used for navigating the server list and other operations because it enables the user to discover the keyboard shortcuts by exploring the menu

