### PR TITLE
macOS: Call "/disconnect" before quitting

### DIFF
--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -119,8 +119,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         func handleQuitConfirmationResult(_ result: NSApplication.ModalResponse) {
             if case .alertFirstButtonReturn = result {
-                firstly {
-                    connectionService.disableVPN()
+                firstly { () -> Promise<Void> in
+                    guard let connectionVC = mainViewController?.currentConnectionVC else {
+                        return connectionService.disableVPN()
+                    }
+                    return connectionVC.disableVPN(shouldFireAndForget: false)
                 }.map { _ in
                     NSApp.reply(toApplicationShouldTerminate: true)
                 }.cauterize()

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -234,14 +234,14 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
                 beginVPNConfigConnectionFlow()
             }
         } else {
-            disableVPN()
+            disableVPN(shouldFireAndForget: true)
         }
     }
 
     @discardableResult
-    func disableVPN() -> Promise<Void> {
+    func disableVPN(shouldFireAndForget: Bool = true) -> Promise<Void> {
         firstly {
-            viewModel.disableVPN()
+            viewModel.disableVPN(shouldFireAndForget: shouldFireAndForget)
         }.map {
             self.vpnSwitch.isOn = false
         }.recover { error in
@@ -262,7 +262,7 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
 
     func renewSession() {
         firstly {
-            viewModel.disableVPN()
+            viewModel.disableVPN(shouldFireAndForget: true)
         }.map {
             self.continueServerConnectionFlow(serverAPIOptions: [.ignoreStoredAuthState, .ignoreStoredKeyPair])
         }.catch { error in

--- a/EduVPN/Networking/ServerAPIv2Handler.swift
+++ b/EduVPN/Networking/ServerAPIv2Handler.swift
@@ -103,8 +103,9 @@ struct ServerAPIv2Handler: ServerAPIHandler {
 
     static func attemptToRelinquishTunnelConfiguration(
         baseURL: URL, dataStore: PersistenceService.DataStore, session: Moya.Session,
-        profile: Profile) {
+        profile: Profile, shouldFireAndForget: Bool) -> Promise<Void> {
         // Nothing to do
+        return Promise.value(())
     }
 }
 

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -17,6 +17,7 @@ enum ServerAPIv3Error: Error {
     case wgVPNConfigMissingInterfaceSection
     case expiresResponseHeaderIsInvalid(String?)
     case unexpectedContentTypeOnConnect(String?)
+    case fireAndForgetCallTimedOut
 }
 
 extension ServerAPIv3Error: AppError {
@@ -34,6 +35,8 @@ extension ServerAPIv3Error: AppError {
             return "Invalid expiration date value"
         case .unexpectedContentTypeOnConnect:
             return "Unexpected content type value"
+        case .fireAndForgetCallTimedOut:
+            return "Disconnect call timed out"
         }
     }
 
@@ -152,7 +155,7 @@ struct ServerAPIv3Handler: ServerAPIHandler {
             Self.fireAndForget(target: target)
             return Promise.value(())
         } else {
-            return Self.fire(target: target)
+            return Self.fire(target: target, timeout: 3 /* seconds */)
         }
     }
 }
@@ -325,7 +328,7 @@ private extension ServerAPIv3Handler {
         var authorizationType: AuthorizationType? { .bearer }
     }
 
-    static func fire(target: FireAndForgetAPITarget) -> Promise<Void> {
+    private static func fire(target: FireAndForgetAPITarget) -> Promise<Void> {
         firstly { () -> Promise<String> in
             if let authState = target.dataStore.authState {
                 return Self.getFreshAccessToken(using: authState, storingChangesTo: target.dataStore)
@@ -350,6 +353,13 @@ private extension ServerAPIv3Handler {
                 }
             }
         }
+    }
+
+    static func fire(target: FireAndForgetAPITarget, timeout: TimeInterval) -> Promise<Void> {
+        let timedPromise = after(seconds: timeout).done {
+            throw ServerAPIv3Error.fireAndForgetCallTimedOut
+        }
+        return race(fire(target: target), timedPromise)
     }
 
     static func fireAndForget(target: FireAndForgetAPITarget) {

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -134,12 +134,13 @@ class ServerAPIService {
     func attemptToRelinquishTunnelConfiguration(
         apiVersion: ServerInfo.APIVersion,
         baseURL: URL, dataStore: PersistenceService.DataStore,
-        profile: Profile) {
+        profile: Profile, shouldFireAndForget: Bool) -> Promise<Void> {
 
         let serverAPIHandler = Self.serverAPIHandlerType(for: apiVersion)
-        serverAPIHandler.attemptToRelinquishTunnelConfiguration(
+        return serverAPIHandler.attemptToRelinquishTunnelConfiguration(
             baseURL: baseURL, dataStore: dataStore,
-            session: Self.uncachedSession, profile: profile)
+            session: Self.uncachedSession, profile: profile,
+            shouldFireAndForget: shouldFireAndForget)
     }
 }
 
@@ -154,7 +155,7 @@ protocol ServerAPIHandler {
         options: ServerAPIService.Options) -> Promise<ServerAPIService.TunnelConfigurationData>
     static func attemptToRelinquishTunnelConfiguration(
         baseURL: URL, dataStore: PersistenceService.DataStore, session: Moya.Session,
-        profile: Profile)
+        profile: Profile, shouldFireAndForget: Bool) -> Promise<Void>
 }
 
 extension ServerAPIHandler {


### PR DESCRIPTION
The macOS app should ensure that "/disconnect" is called and wait a few seconds for it to succeed before quitting.
