### PR TITLE
Make fetching info.json cancellable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- macOS: Support keyboard navigation
+- Make fetching of info.json cancellable #415
+
 ## 2.2.3
 
 - Support for APIv3 and WireGuard

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -591,7 +591,7 @@ extension ConnectionViewController: ConnectionViewModelDelegate {
         _ model: ConnectionViewModel, statusChanged status: ConnectionViewModel.ConnectionFlowStatus) {
         connectionStatusImageView.image = { () -> Image? in
             switch status {
-            case .notConnected, .gettingProfiles, .configuring:
+            case .notConnected, .gettingServerInfo, .gettingProfiles, .configuring:
                 return Image(named: "StatusNotConnected")
             case .connecting, .reconnecting, .disconnecting:
                 return Image(named: "StatusConnecting")

--- a/EduVPN/Controllers/Mac/StatusItemController.swift
+++ b/EduVPN/Controllers/Mac/StatusItemController.swift
@@ -196,7 +196,7 @@ private extension StatusItemController {
         guard let statusItem = statusItem else { return }
         statusItem.button?.image = {
             switch flowStatus {
-            case .notConnected, .gettingProfiles, .configuring:
+            case .notConnected, .gettingServerInfo, .gettingProfiles, .configuring:
                 return shouldUseColorIcons ?
                     NSImage(named: "StatusItemColorNotConnected") :
                     NSImage(named: "StatusItemGrayscaleNotConnected")

--- a/EduVPN/Networking/Moya/Moya+Promise.swift
+++ b/EduVPN/Networking/Moya/Moya+Promise.swift
@@ -20,7 +20,7 @@ public extension MoyaProvider {
     }
     
     func requestCancellable(target: Target,
-                            queue: DispatchQueue?,
+                            queue: DispatchQueue? = nil,
                             progress: Moya.ProgressBlock? = nil) -> PendingRequestPromise {
         
         let pending = Promise<Moya.Response>.pending()

--- a/EduVPN/Networking/ServerInfoFetcher.swift
+++ b/EduVPN/Networking/ServerInfoFetcher.swift
@@ -37,7 +37,7 @@ extension ServerInfoFetcherError: AppError {
     }
 }
 
-struct ServerInfoFetcher {
+class ServerInfoFetcher {
 
     struct ServerInfoTarget: TargetType, AcceptJson, SimpleGettable {
         var baseURL: URL
@@ -48,14 +48,14 @@ struct ServerInfoFetcher {
         }
     }
 
-    static var uncachedSession: Moya.Session {
+    let uncachedSession: Moya.Session = {
         let configuration = URLSessionConfiguration.default
         configuration.urlCache = nil
         return Session(configuration: configuration, startRequestsImmediately: false)
-    }
+    }()
 
-    static func fetch(baseURLString: DiscoveryData.BaseURLString) -> Promise<ServerInfo> {
-        let provider = MoyaProvider<ServerInfoTarget>(session: Self.uncachedSession)
+    func fetch(baseURLString: DiscoveryData.BaseURLString) -> Promise<ServerInfo> {
+        let provider = MoyaProvider<ServerInfoTarget>(session: self.uncachedSession)
         return firstly {
             provider.request(target: ServerInfoTarget(try baseURLString.toURL()))
         }.map { response in
@@ -63,8 +63,8 @@ struct ServerInfoFetcher {
         }
     }
 
-    static func fetch(apiBaseURLString: DiscoveryData.BaseURLString,
-                      authBaseURLString: DiscoveryData.BaseURLString) -> Promise<ServerInfo> {
+    func fetch(apiBaseURLString: DiscoveryData.BaseURLString,
+               authBaseURLString: DiscoveryData.BaseURLString) -> Promise<ServerInfo> {
         guard apiBaseURLString != authBaseURLString else {
             return fetch(baseURLString: authBaseURLString)
         }
@@ -72,7 +72,7 @@ struct ServerInfoFetcher {
             let apiBaseURL = try apiBaseURLString.toURL()
             let authBaseURL = try authBaseURLString.toURL()
 
-            let provider = MoyaProvider<ServerInfoTarget>(session: Self.uncachedSession)
+            let provider = MoyaProvider<ServerInfoTarget>(session: self.uncachedSession)
             let apiServerInfoPromise = provider.request(target: ServerInfoTarget(apiBaseURL))
             let authServerInfoPromise = provider.request(target: ServerInfoTarget(authBaseURL))
 

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -87,6 +87,10 @@ class ServerAPIService {
                                 authBaseURLString: server.authBaseURLString)
     }
 
+    func cancelGetServerInfo() {
+        serverInfoFetcher.cancelFetch()
+    }
+
     func getAvailableProfiles(for server: ServerInstance, serverInfo: ServerInfo?,
                               from viewController: AuthorizingViewController,
                               wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -65,10 +65,12 @@ class ServerAPIService {
     }
 
     private let serverAuthService: ServerAuthService
+    private let serverInfoFetcher: ServerInfoFetcher
     private var authStateChangeHandler: AuthStateChangeHandler?
 
     init(serverAuthService: ServerAuthService) {
         self.serverAuthService = serverAuthService
+        self.serverInfoFetcher = ServerInfoFetcher()
     }
 
     private static func serverAPIHandlerType(for apiVersion: ServerInfo.APIVersion) -> ServerAPIHandler.Type {
@@ -85,7 +87,7 @@ class ServerAPIService {
                               wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
                               options: Options) -> Promise<([Profile], ServerInfo)> {
         return firstly {
-            ServerInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
+            serverInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
                                     authBaseURLString: server.authBaseURLString)
         }.then { serverInfo -> Promise<([Profile], ServerInfo)> in
             let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
@@ -114,7 +116,7 @@ class ServerAPIService {
             if let serverInfo = serverInfo {
                 return Promise.value(serverInfo)
             }
-            return ServerInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
+            return serverInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
                                            authBaseURLString: server.authBaseURLString)
         }.then { serverInfo -> Promise<TunnelConfigurationData> in
             let dataStore = PersistenceService.DataStore(path: server.localStoragePath)

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -82,13 +82,21 @@ class ServerAPIService {
         }
     }
 
-    func getAvailableProfiles(for server: ServerInstance,
+    func getServerInfo(for server: ServerInstance) -> Promise<ServerInfo> {
+        serverInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
+                                authBaseURLString: server.authBaseURLString)
+    }
+
+    func getAvailableProfiles(for server: ServerInstance, serverInfo: ServerInfo?,
                               from viewController: AuthorizingViewController,
                               wayfSkippingInfo: ServerAuthService.WAYFSkippingInfo?,
                               options: Options) -> Promise<([Profile], ServerInfo)> {
-        return firstly {
-            serverInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
-                                    authBaseURLString: server.authBaseURLString)
+        return firstly { () -> Promise<ServerInfo> in
+            if let serverInfo = serverInfo {
+                return Promise.value(serverInfo)
+            }
+            return serverInfoFetcher.fetch(apiBaseURLString: server.apiBaseURLString,
+                                           authBaseURLString: server.authBaseURLString)
         }.then { serverInfo -> Promise<([Profile], ServerInfo)> in
             let dataStore = PersistenceService.DataStore(path: server.localStoragePath)
             let commonInfo = ServerAPIService.CommonAPIRequestInfo(

--- a/EduVPN/Services/ServerAuthService.swift
+++ b/EduVPN/Services/ServerAuthService.swift
@@ -28,6 +28,7 @@ class ServerAuthService {
 
     private let configRedirectURL: URL // For iOS
     private let configClientId: String // For macOS
+    private let serverInfoFetcher: ServerInfoFetcher
 
     private var currentAuthFlow: OIDExternalUserAgentSession?
 
@@ -49,6 +50,7 @@ class ServerAuthService {
     init(configRedirectURL: URL, configClientId: String) {
         self.configRedirectURL = configRedirectURL
         self.configClientId = configClientId
+        self.serverInfoFetcher = ServerInfoFetcher()
     }
 
     func startAuth(baseURLString: DiscoveryData.BaseURLString,
@@ -59,7 +61,7 @@ class ServerAuthService {
             isUserCancelled = true
         })
         return firstly {
-            ServerInfoFetcher.fetch(baseURLString: baseURLString)
+            serverInfoFetcher.fetch(baseURLString: baseURLString)
         }.then { serverInfo -> Promise<AuthState> in
             if isUserCancelled {
                 throw ServerAuthServiceError.userCancelledWhenFetchingServerInfo

--- a/EduVPN/Services/ServerAuthService.swift
+++ b/EduVPN/Services/ServerAuthService.swift
@@ -6,6 +6,7 @@
 import Foundation
 import AppAuth
 import Moya
+import Alamofire
 import PromiseKit
 
 #if os(iOS)
@@ -133,8 +134,11 @@ class ServerAuthService {
         if case ServerAuthServiceError.userCancelledWhenFetchingServerInfo = error {
             return true
         }
-        #if os(iOS)
         let underlyingError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? Error
+        if case Alamofire.AFError.explicitlyCancelled = (underlyingError ?? error) {
+            return true
+        }
+        #if os(iOS)
         if case ASWebAuthenticationSessionError.canceledLogin = (underlyingError ?? error) {
             return true
         }

--- a/EduVPN/ViewModels/ConnectionViewModel+Localization.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel+Localization.swift
@@ -8,6 +8,7 @@ import Foundation
 extension ConnectionViewModel.ConnectionFlowStatus {
     var localizedText: String {
         switch self {
+        case .gettingServerInfo: return NSLocalizedString("Contacting the server...", comment: "connection flow status")
         case .gettingProfiles: return NSLocalizedString("Getting profiles...", comment: "connection flow status")
         case .configuring: return NSLocalizedString("Configuring...", comment: "connection flow status")
         case .notConnected: return NSLocalizedString("Not connected", comment: "connection flow status")

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -318,7 +318,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
         return firstly { () -> Promise<([Profile], ServerInfo)> in
             self.internalState = .gettingProfiles
             return serverAPIService.getAvailableProfiles(
-                for: server, from: viewController,
+                for: server, serverInfo: nil, from: viewController,
                 wayfSkippingInfo: wayfSkippingInfo(), options: [])
         }.then { (profiles, serverInfo) -> Promise<Void> in
             self.profiles = profiles

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -588,7 +588,7 @@ private extension ConnectionViewModel {
 
     func updateStatusDetail() {
         statusDetail = { () -> StatusDetail in
-            if internalState == .gettingProfiles || internalState == .configuring {
+            if internalState == .gettingServerInfo || internalState == .gettingProfiles || internalState == .configuring {
                 return .none
             }
             if (connectableInstance is ServerInstance) &&
@@ -626,7 +626,7 @@ private extension ConnectionViewModel {
                 // Make space for the expanded connection info
                 return .none
             }
-            if internalState == .gettingProfiles || internalState == .configuring {
+            if internalState == .gettingServerInfo || internalState == .gettingProfiles || internalState == .configuring {
                 return .spinner
             }
             if (certificateStatus?.shouldShowRenewSessionButton ?? false) && internalState == .enabledVPN {


### PR DESCRIPTION
This PR fixes #415.

To reproduce the issue reported in #415 in the macOS app:

- Ensure you have added a Secure Internet server in the app. Australia might not be available in the UI. Quit the app.
- Remove the cached server_list.json and organization_list.json by deleting everything under ~/Library/Containers/<bundle_id>/Data/Library/Caches/DiscoveryData
- Turn off wifi / ethernet on your Mac. Open the app. The server_list.json and organization_list.json bundled with the app still have Australia as a Secure Internet location, so when we open the app, we can now see Australia in the UI. Select Australia as the Secure Internet location.
- Turn on wifi / ethernet. Click on the Australia list item to start the connection flow. The connection screen is pushed in, saying "Getting Profiles...", and the spinner spins for 1 min (till the timed-out error is shown), during which we can't cancel the operation -- we can only wait.

This PR fixes this by doing the following:

- Introduce a new state while we fetch the info.json
- While we're in that state, keep the VPN switch enabled -- if the switch is turned off at that time, the info.json fetching operation is cancelled
