### PR TITLE
Search UX: Handle wrong scheme in custom server URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- macOS: Support keyboard navigation
+- macOS: Support keyboard navigation #331
 - Make fetching of info.json cancellable #415
+- Handle wrong scheme when pasting a custom server URL #407
 
 ## 2.2.3
 

--- a/EduVPN/ViewModels/SearchViewModel.swift
+++ b/EduVPN/ViewModels/SearchViewModel.swift
@@ -184,7 +184,17 @@ private extension SearchViewModel {
         let hasTwoOrMoreDots = searchQuery.filter { $0 == "." }.count >= 2
         if hasTwoOrMoreDots {
             var url = searchQuery.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-            if !url.hasPrefix("https://") {
+            if url.hasPrefix("https://") {
+                // Do nothing
+            } else if url.hasPrefix("http://") {
+                // Replace http with https
+                url.removeFirst("http://".count)
+                url = "https://" + url
+            } else if url.firstIndex(of: ":") != nil {
+                // If scheme is neither http nor https, reject it
+                return []
+            } else {
+                // If there's no scheme, add the https scheme
                 url = "https://" + url
             }
             if !url.hasSuffix("/") {


### PR DESCRIPTION
Fixes #407.

- If the scheme is 'http', change that to 'https'.
- If the scheme is neither 'http' nor 'https', don't consider it to be a custom server URL.
- If the scheme is 'https', consider that to be valid as is.
