### PR TITLE
Remove enforcing of OCSP stapling

### DIFF
--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -46,22 +46,12 @@ class ServerAPIService {
         let sourceViewController: AuthorizingViewController
     }
 
-    class OCSPStaplingEnforcedTrustManager: ServerTrustManager {
-        init() {
-            super.init(allHostsMustBeEvaluated: true, evaluators: [:])
-        }
-        override func serverTrustEvaluator(forHost host: String) throws -> ServerTrustEvaluating? {
-            return RevocationTrustEvaluator(options: [.ocsp, .requirePositiveResponse])
-        }
-    }
-
     static var uncachedSession: Moya.Session {
         let configuration = URLSessionConfiguration.default
         configuration.urlCache = nil
         return Session(
             configuration: configuration,
-            startRequestsImmediately: false,
-            serverTrustManager: OCSPStaplingEnforcedTrustManager())
+            startRequestsImmediately: false)
     }
 
     private let serverAuthService: ServerAuthService


### PR DESCRIPTION
This PR removes the code for OCSP stapling (that wasn't fully working) added in PR #411.

I can see that OCSP stapling is enforced (i.e. app doesn't connect if there's no
stapled OCSP response in the TLS handshake) if we use the following options:

  - kSecRevocationOCSPMethod
  - kSecRevocationRequirePositiveResponse
  - kSecRevocationNetworkAccessDisabled

But some eduVPN servers (e.g. Secure Internet servers of Finland and
France) have OCSP stapling disabled, so we don't want to enforce OCSP
stapling at present.