### PR TITLE
Suppress renewal when the browser session is active from authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - macOS: Support keyboard navigation #331
 - Make fetching of info.json cancellable #415
 - Handle wrong scheme when pasting a custom server URL #407
+- Make "Connect using TCP only" work with APIv3
+- Suppress 'Renew Session' for 30 mins after authentication time #417
 
 ## 2.2.3
 

--- a/EduVPN/Models/ConnectionAttempt.swift
+++ b/EduVPN/Models/ConnectionAttempt.swift
@@ -21,6 +21,7 @@ struct ConnectionAttempt {
         let profiles: [Profile]
         let selectedProfileId: String
         let sessionExpiresAt: Date
+        let sessionAuthenticatedAt: Date?
         let serverAPIBaseURL: URL
         let serverAPIVersion: ServerInfo.APIVersion
     }
@@ -55,6 +56,7 @@ struct ConnectionAttempt {
     init(server: ServerInstance, profiles: [Profile],
          selectedProfileId: String,
          sessionExpiresAt: Date,
+         sessionAuthenticatedAt: Date?,
          serverAPIBaseURL: URL,
          serverAPIVersion: ServerInfo.APIVersion,
          attemptId: UUID) {
@@ -64,6 +66,7 @@ struct ConnectionAttempt {
                 profiles: profiles,
                 selectedProfileId: selectedProfileId,
                 sessionExpiresAt: sessionExpiresAt,
+                sessionAuthenticatedAt: sessionAuthenticatedAt,
                 serverAPIBaseURL: serverAPIBaseURL,
                 serverAPIVersion: serverAPIVersion))
         self.attemptId = attemptId
@@ -83,6 +86,7 @@ extension ConnectionAttempt.ServerPreConnectionState: Codable {
         case profiles
         case selectedProfileId = "selected_profile_id"
         case sessionExpiresAt = "session_expires_at"
+        case sessionAuthenticatedAt = "session_authenticated_at"
         case serverAPIBaseURL = "api_base_url"
         case serverAPIVersion = "api_version"
     }

--- a/EduVPN/Networking/ServerAPIv2Handler.swift
+++ b/EduVPN/Networking/ServerAPIv2Handler.swift
@@ -92,9 +92,11 @@ struct ServerAPIv2Handler: ServerAPIHandler {
                 let isUDPAllowed = !UserDefaults.standard.forceTCP
                 let openVPNConfig = try Self.createOpenVPNConfig(
                     profileConfig: profileConfig, isUDPAllowed: isUDPAllowed, keyPair: keyPairData.keyPair)
+                let authenticationTime = commonInfo.dataStore.authenticationTime
                 return ServerAPIService.TunnelConfigurationData(
                     vpnConfig: .openVPNConfig(openVPNConfig),
                     expiresAt: keyPairData.certificateExpiryDate,
+                    authenticationTime: authenticationTime,
                     serverAPIBaseURL: commonInfo.serverInfo.apiBaseURL,
                     serverAPIVersion: commonInfo.serverInfo.apiVersion)
             }

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -125,12 +125,15 @@ struct ServerAPIv3Handler: ServerAPIHandler {
                 throw ServerAPIv3Error.expiresResponseHeaderIsInvalid(expiresString)
             }
 
+            let authenticationTime = commonInfo.dataStore.authenticationTime
+
             switch responseData.contentTypeResponseHeader {
             case "application/x-openvpn-profile":
                 let configLines = configString.split(separator: "\n").map { String($0) }
                 return ServerAPIService.TunnelConfigurationData(
                     vpnConfig: .openVPNConfig(configLines),
                     expiresAt: expiresDate,
+                    authenticationTime: authenticationTime,
                     serverAPIBaseURL: commonInfo.serverInfo.apiBaseURL,
                     serverAPIVersion: commonInfo.serverInfo.apiVersion)
             case "application/x-wireguard-profile":
@@ -138,6 +141,7 @@ struct ServerAPIv3Handler: ServerAPIHandler {
                 return ServerAPIService.TunnelConfigurationData(
                     vpnConfig: .wireGuardConfig(updatedConfigString),
                     expiresAt: expiresDate,
+                    authenticationTime: authenticationTime,
                     serverAPIBaseURL: commonInfo.serverInfo.apiBaseURL,
                     serverAPIVersion: commonInfo.serverInfo.apiVersion)
             default:

--- a/EduVPN/Services/PersistenceService.swift
+++ b/EduVPN/Services/PersistenceService.swift
@@ -254,6 +254,10 @@ extension PersistenceService {
             rootURL.appendingPathComponent("authState.bin")
         }
 
+        private var authenticationTimeURL: URL {
+            rootURL.appendingPathComponent("authenticationTime.json")
+        }
+
         private var keyPairURL: URL {
             rootURL.appendingPathComponent("keyPair.bin")
         }
@@ -294,6 +298,25 @@ extension PersistenceService {
                     PersistenceService.write(encryptedData, to: authStateURL, atomically: true)
                 } else {
                     removeAuthState()
+                }
+            }
+        }
+
+        var authenticationTime: Date? {
+            get {
+                if let data = try? Data(contentsOf: authenticationTimeURL),
+                   let date = try? JSONDecoder().decode(Date.self, from: data) {
+                    return date
+                }
+                return nil
+            }
+            set(value) {
+                if let data = try? JSONEncoder().encode(value) {
+                    PersistenceService.write(data, to: authenticationTimeURL, atomically: true)
+                } else {
+                    if FileManager.default.fileExists(atPath: authenticationTimeURL.path) {
+                        try? FileManager.default.removeItem(at: authenticationTimeURL)
+                    }
                 }
             }
         }

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -33,6 +33,7 @@ class ServerAPIService {
     struct TunnelConfigurationData {
         let vpnConfig: VPNConfiguration
         let expiresAt: Date
+        let authenticationTime: Date?
         let serverAPIBaseURL: URL
         let serverAPIVersion: ServerInfo.APIVersion
     }
@@ -189,6 +190,7 @@ extension ServerAPIHandler {
                     wayfSkippingInfo: commonInfo.wayfSkippingInfo)
                 .then { authState -> Promise<String> in
                     commonInfo.dataStore.authState = authState
+                    commonInfo.dataStore.authenticationTime = Date()
                     return self.getFreshAccessToken(using: authState, storingChangesTo: commonInfo.dataStore)
                 }
             default:

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -433,7 +433,8 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 return Promise.value(())
             }
             return notificationService.attemptSchedulingSessionExpiryNotification(
-                expiryDate: expiresAt, connectionAttemptId: connectionAttemptId, from: viewController)
+                expiryDate: expiresAt, authenticationDate: authenticatedAt,
+                connectionAttemptId: connectionAttemptId, from: viewController)
                 .map { _ in }
         }.ensure {
             self.internalState = self.connectionService.isVPNEnabled ? .enabledVPN : .idle
@@ -551,7 +552,9 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
            let expiryDate = certificateExpiryHelper?.expiresAt,
            let notificationService = notificationService {
             return notificationService.scheduleSessionExpiryNotification(
-                expiryDate: expiryDate, connectionAttemptId: connectionAttemptId)
+                expiryDate: expiryDate,
+                authenticationDate: certificateExpiryHelper?.authenticatedAt,
+                connectionAttemptId: connectionAttemptId)
         }
         return Guarantee<Bool>.value(false)
     }


### PR DESCRIPTION
Whenever the app successfully performs an OAuth authorization using a browser, the app shall note down that time as the authorization time. The renew button and the session-about-expire notification shall be suppressed 32 mins from that time (because the browser session shall be active for 30 mins -- the 2 mins is a buffer).
