### PR TITLE
Handle ENOBUFS (No buffer space) errors in TunnelKit more gracefully

### DIFF
--- a/Pods/TunnelKit/TunnelKit/Sources/AppExtension/Transport/NETunnelInterface.swift
+++ b/Pods/TunnelKit/TunnelKit/Sources/AppExtension/Transport/NETunnelInterface.swift
@@ -59,17 +59,16 @@ public class NETunnelInterface: TunnelInterface {
     // MARK: IOInterface
     
     /// :nodoc:
-    public func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void) {
+    public func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?, @escaping () -> Void) -> Void) {
         loopReadPackets(queue, handler)
     }
     
-    private func loopReadPackets(_ queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void) {
+    private func loopReadPackets(_ queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?, @escaping () -> Void) -> Void) {
 
         // WARNING: runs in NEPacketTunnelFlow queue
         impl?.readPackets { [weak self] (packets, protocols) in
-            queue.sync {
+            handler(packets, nil) {
                 self?.loopReadPackets(queue, handler)
-                handler(packets, nil)
             }
         }
     }

--- a/Pods/TunnelKit/TunnelKit/Sources/Core/TunnelInterface.swift
+++ b/Pods/TunnelKit/TunnelKit/Sources/Core/TunnelInterface.swift
@@ -47,8 +47,9 @@ public protocol TunnelInterface {
 
      - Parameter queue: The queue where to invoke the handler on.
      - Parameter handler: The handler invoked whenever an array of `Data` packets is received, with an optional `Error` in case a network failure occurs.
+                          The handler also receives a closure that the handler should call on successful completion of handling the read.
      */
-    func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void)
+    func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?, @escaping () -> Void) -> Void)
 
     /**
      Writes a packet to the interface.

--- a/Pods/TunnelKit/TunnelKit/Sources/Core/TunnelInterface.swift
+++ b/Pods/TunnelKit/TunnelKit/Sources/Core/TunnelInterface.swift
@@ -37,8 +37,32 @@
 import Foundation
 
 /// Represents a specific I/O interface meant to work at the tunnel layer (e.g. VPN).
-public protocol TunnelInterface: IOInterface {
+public protocol TunnelInterface {
 
     /// When `true`, interface survives sessions.
     var isPersistent: Bool { get }
+
+    /**
+     Sets the handler for incoming packets. This only needs to be set once.
+
+     - Parameter queue: The queue where to invoke the handler on.
+     - Parameter handler: The handler invoked whenever an array of `Data` packets is received, with an optional `Error` in case a network failure occurs.
+     */
+    func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void)
+
+    /**
+     Writes a packet to the interface.
+
+     - Parameter packet: The `Data` packet to write.
+     - Parameter completionHandler: Invoked on write completion, with an optional `Error` in case a network failure occurs.
+     */
+    func writePacket(_ packet: Data, completionHandler: ((Error?) -> Void)?)
+
+    /**
+     Writes some packets to the interface.
+
+     - Parameter packets: The array of `Data` packets to write.
+     - Parameter completionHandler: Invoked on write completion, with an optional `Error` in case a network failure occurs.
+     */
+    func writePackets(_ packets: [Data], completionHandler: ((Error?) -> Void)?)
 }

--- a/Pods/TunnelKit/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/Pods/TunnelKit/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -162,7 +162,9 @@ public class OpenVPNSession: Session {
     private var lastPing: BidirectionalState<Date>
     
     private(set) var isStopping: Bool
-    
+
+    private var isWaitingForSendBufferSpace: Bool
+
     /// The optional reason why the session stopped.
     public private(set) var stopError: Error?
     
@@ -212,7 +214,8 @@ public class OpenVPNSession: Session {
         isRenegotiating = false
         lastPing = BidirectionalState(withResetValue: Date.distantPast)
         isStopping = false
-        
+        isWaitingForSendBufferSpace = false
+
         if let tlsWrap = configuration.tlsWrap {
             switch tlsWrap.strategy {
             case .auth:
@@ -410,8 +413,14 @@ public class OpenVPNSession: Session {
                 return
             }
             if let error = error {
-                log.error("Failed LINK read: \(error)")
-                
+
+                if self?.isWaitingForSendBufferSpace ?? false,
+                   let posixError = error as? POSIXError, posixError.code == POSIXErrorCode.ENOBUFS {
+                    // Suppress logging this error
+                } else {
+                    log.error("Failed LINK read: \(error)")
+                }
+
                 // XXX: why isn't the tunnel shutting down at this point?
                 return
             }
@@ -1185,7 +1194,9 @@ public class OpenVPNSession: Session {
                 if let error = error {
                     if let posixError = error as? POSIXError, posixError.code == POSIXErrorCode.ENOBUFS {
                         log.debug("Data: Encountered ENOBUFS while sending. Will retry after 1 second.")
+                        self.isWaitingForSendBufferSpace = true
                         self.queue.asyncAfter(deadline: .now() + .milliseconds(1000)) {
+                            self.isWaitingForSendBufferSpace = false
                             self.sendDataPackets(packets, onSuccess: onSuccess)
                         }
                     } else {

--- a/Pods/TunnelKit/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/Pods/TunnelKit/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -1175,16 +1175,27 @@ public class OpenVPNSession: Session {
             controlChannel.addSentDataCount(encryptedPackets.flatCount)
             let writeLink = link
             link?.writePackets(encryptedPackets) { [weak self] (error) in
-                guard self?.link === writeLink else {
+                guard let self = self else {
+                    return
+                }
+                guard self.link === writeLink else {
                     log.warning("Ignoring write from outdated LINK")
                     return
                 }
                 if let error = error {
-                    log.error("Data: Failed LINK write during send data: \(error)")
-                    self?.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
-                    return
+                    if let posixError = error as? POSIXError, posixError.code == POSIXErrorCode.ENOBUFS {
+                        log.debug("Data: Encountered ENOBUFS while sending. Will retry after 1 second.")
+                        self.queue.asyncAfter(deadline: .now() + .milliseconds(1000)) {
+                            self.sendDataPackets(packets, onSuccess: onSuccess)
+                        }
+                    } else {
+                        log.error("Data: Failed LINK write during send data: \(error)")
+                        self.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
+                    }
+                } else {
+                    // Trigger getting of more to-be-sent-out packets from the TUN interface
+                    onSuccess()
                 }
-                onSuccess()
 //              log.verbose("Data: \(encryptedPackets.count) packets successfully written to LINK")
             }
         } catch let e {

--- a/Pods/TunnelKit/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/Pods/TunnelKit/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -427,7 +427,7 @@ public class OpenVPNSession: Session {
 
     // Ruby: tun_loop
     private func loopTunnel() {
-        tunnel?.setReadHandler(queue: queue) { [weak self] (newPackets, error) in
+        tunnel?.setReadHandler(queue: queue) { [weak self] (newPackets, error, onSuccess) in
             if let error = error {
                 log.error("Failed TUN read: \(error)")
                 return
@@ -435,7 +435,7 @@ public class OpenVPNSession: Session {
 
             if let packets = newPackets, !packets.isEmpty {
 //                log.verbose("Received \(packets.count) packets from TUN")
-                self?.receiveTunnel(packets: packets)
+                self?.receiveTunnel(packets: packets, onSuccess: onSuccess)
             }
         }
     }
@@ -541,12 +541,12 @@ public class OpenVPNSession: Session {
     }
     
     // Ruby: recv_tun
-    private func receiveTunnel(packets: [Data]) {
+    private func receiveTunnel(packets: [Data], onSuccess: @escaping () -> Void) {
         guard shouldHandlePackets() else {
             log.warning("Discarding \(packets.count) TUN packets (should not handle)")
             return
         }
-        sendDataPackets(packets)
+        sendDataPackets(packets, onSuccess: onSuccess)
     }
     
     // Ruby: ping
@@ -564,7 +564,7 @@ public class OpenVPNSession: Session {
         // is keep-alive enabled?
         if let _ = keepAliveInterval {
             log.debug("Send ping")
-            sendDataPackets([OpenVPN.DataPacket.pingString])
+            sendDataPackets([OpenVPN.DataPacket.pingString], onSuccess: {})
             lastPing.outbound = Date()
         }
 
@@ -1158,7 +1158,7 @@ public class OpenVPNSession: Session {
     }
     
     // Ruby: send_data_pkt
-    private func sendDataPackets(_ packets: [Data]) {
+    private func sendDataPackets(_ packets: [Data], onSuccess: @escaping () -> Void) {
         guard let key = currentKey else {
             return
         }
@@ -1175,18 +1175,17 @@ public class OpenVPNSession: Session {
             controlChannel.addSentDataCount(encryptedPackets.flatCount)
             let writeLink = link
             link?.writePackets(encryptedPackets) { [weak self] (error) in
-                self?.queue.sync {
-                    guard self?.link === writeLink else {
-                        log.warning("Ignoring write from outdated LINK")
-                        return
-                    }
-                    if let error = error {
-                        log.error("Data: Failed LINK write during send data: \(error)")
-                        self?.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
-                        return
-                    }
-//                    log.verbose("Data: \(encryptedPackets.count) packets successfully written to LINK")
+                guard self?.link === writeLink else {
+                    log.warning("Ignoring write from outdated LINK")
+                    return
                 }
+                if let error = error {
+                    log.error("Data: Failed LINK write during send data: \(error)")
+                    self?.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
+                    return
+                }
+                onSuccess()
+//              log.verbose("Data: \(encryptedPackets.count) packets successfully written to LINK")
             }
         } catch let e {
             guard !e.isTunnelKitError() else {


### PR DESCRIPTION
This is an attempt to handle errors like this:

~~~
2021-10-18 14:32:43.529 ERROR OpenVPNSession.sendDataPackets():1181 - 
Data: Failed LINK write during send data: Error 
Domain=NSPOSIXErrorDomain Code=55 "No buffer space available"
2021-10-18 14:32:43.529 ERROR OpenVPNSession.doShutdown():1280 - Trigger 
shutdown (error: failedLinkWrite)
2021-10-18 14:32:43.530 ERROR OpenVPNTunnelProvider.sessionDidStop():599 
- Session did stop with error: failedLinkWrite
2021-10-18 14:32:43.530 ERROR OpenVPNSession.loopLink():410 - Failed 
LINK read: Error Domain=NSPOSIXErrorDomain Code=89 "Operation canceled"
2021-10-18 14:32:43.530 DEBUG 
NEUDPSocket.observeValueInTunnelQueue():147 - Socket state is cancelled 
(endpoint: 145.100.179.14:1201 -> 145.100.179.14:1201)
2021-10-18 14:32:43.530 INFO OpenVPNSession.cleanup():334 - Cleaning up...
2021-10-18 14:32:43.531 ERROR 
OpenVPNTunnelProvider.finishTunnelDisconnection():370 - Tunnel did stop 
(error: failedLinkWrite)
~~~

To handle this, this PR:
- Restructures reading from the TUN interface (data to be sent out) to be done only after the previous read is handled successfully
- On encountering ENOBUFS, waits for 1 second, then tries to send the data again, and then triggers the next read from the TUN interface
