### PR TITLE
Add support for prehashed minisign signatures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support for minisign pre-hashed signatures #427
+
 ## 2.2.4
 
 - macOS: Support keyboard navigation #331

--- a/EduVPN/Helpers/SignatureHelper.swift
+++ b/EduVPN/Helpers/SignatureHelper.swift
@@ -69,28 +69,23 @@ struct SignatureHelper {
             throw SignatureHelperError.invalidSignature
         }
         
-        guard publicKeyWithMetadata.subdata(in: 0..<10) == signatureWithMetadata.subdata(in: 0..<10) else {
+        guard publicKeyWithMetadata.subdata(in: 2..<10) == signatureWithMetadata.subdata(in: 2..<10) else {
             throw SignatureHelperError.publicKeySignatureMismatch
         }
-        
-        guard publicKeyWithMetadata.subdata(in: 0..<2) == "Ed".data(using: .utf8) else {
+
+        let signatureAlgorithmId = String(data: signatureWithMetadata.subdata(in: 0..<2), encoding: .utf8)
+        guard signatureAlgorithmId == "Ed" || signatureAlgorithmId == "ED" else {
             throw SignatureHelperError.unsupportedAlgorithm
         }
         
         let publicKey = publicKeyWithMetadata.subdata(in: 10..<42)
         let signature = signatureWithMetadata.subdata(in: 10..<74)
         
-        let isVerified: Bool
-        
-        if #available(iOS 13.0, macOS 10.15, *) {
-            let cryptoKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKey)
-            isVerified = cryptoKey.isValidSignature(signature, for: data)
-        } else {
-            isVerified = self.verify(message: Array(data),
-                                     publicKey: Array(publicKey),
-                                     signature: Array(signature))
-        }
-        
+        let isVerified: Bool = self.verify(message: Array(data),
+                                           publicKey: Array(publicKey),
+                                           signature: Array(signature),
+                                           isPreHashed: signatureAlgorithmId == "ED")
+
         guard isVerified else {
             throw SignatureHelperError.invalid
         }
@@ -109,15 +104,37 @@ struct SignatureHelper {
 
     private typealias Bytes = [UInt8]
     
-    private static func verify(message: Bytes, publicKey: Bytes, signature: Bytes) -> Bool {
+    private static func verify(message: Bytes, publicKey: Bytes, signature: Bytes, isPreHashed: Bool) -> Bool {
         guard publicKey.count == 32 else {
             return false
         }
-        
-        return 0 == crypto_sign_verify_detached(signature,
-                                                message,
-                                                UInt64(message.count),
-                                                publicKey)
+
+        let data: Bytes = {
+            if isPreHashed {
+                let hashLength = Int(crypto_generichash_BYTES_MAX)
+                var hash = Bytes(repeating: 0, count: hashLength)
+                crypto_generichash(&hash, hashLength, message, UInt64(message.count), [], 0)
+                return hash
+            } else {
+                return message
+            }
+        }()
+
+        if #available(iOS 13.0, macOS 10.15, *) {
+            // Use CryptoKit
+            do {
+                let cryptoKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKey)
+                return cryptoKey.isValidSignature(signature, for: data)
+            } catch {
+                return false
+            }
+        } else {
+            // Use libsodium
+            return 0 == crypto_sign_verify_detached(signature,
+                                                    data,
+                                                    UInt64(data.count),
+                                                    publicKey)
+        }
     }
     
 }

--- a/EduVPN/Helpers/SignatureHelper.swift
+++ b/EduVPN/Helpers/SignatureHelper.swift
@@ -2,7 +2,7 @@
 //  SignatureHelper.swift
 //  EduVPN
 //
-//  Created by Johan Kool on 10/04/2020.
+//  SignatureHelper: Helper to verify minisign signatures.
 //
 
 import Foundation

--- a/EduVPN/Helpers/SignatureHelper.swift
+++ b/EduVPN/Helpers/SignatureHelper.swift
@@ -13,7 +13,7 @@ enum SignatureHelperError: LocalizedError {
     case signatureFetchFailed
     case invalidPublicKey
     case invalidSignature
-    case publicKeySignatureMismatch
+    case publicKeyIdMismatch
     case unsupportedAlgorithm
     case invalid
     
@@ -31,9 +31,9 @@ enum SignatureHelperError: LocalizedError {
             return NSLocalizedString(
                 "Invalid signature",
                 comment: "error message")
-        case .publicKeySignatureMismatch:
+        case .publicKeyIdMismatch:
             return NSLocalizedString(
-                "Public key and signature mismatch",
+                "Public key id mismatch",
                 comment: "error message")
         case .unsupportedAlgorithm:
             return NSLocalizedString(
@@ -70,7 +70,7 @@ struct SignatureHelper {
         }
         
         guard publicKeyWithMetadata.subdata(in: 2..<10) == signatureWithMetadata.subdata(in: 2..<10) else {
-            throw SignatureHelperError.publicKeySignatureMismatch
+            throw SignatureHelperError.publicKeyIdMismatch
         }
 
         let signatureAlgorithmId = String(data: signatureWithMetadata.subdata(in: 0..<2), encoding: .utf8)


### PR DESCRIPTION
Fixes #427. Tested with pre-hashed and legacy signatures generated with minisign 0.10.

- To disable legacy signature in the future, should set `SignatureHelper.isLegacySignatureAllowed` to `false`
- Apple's CryptoKit doesn't have Blake2s hashing, so we use Blake2s from libsodium. Consequently, we now use libsodium even for latest iOS / macOS.
- The publicKey can still have the signature algorithm id as "Ed" (legacy) instead of "ED" (pre-hashed), so we don't compare the publicKey's signature algorithm id with the signature's signature algorithm id.
