### PR TITLE
macOS: Fix status bar icon

### DIFF
--- a/EduVPN/Controllers/Mac/StatusItemController.swift
+++ b/EduVPN/Controllers/Mac/StatusItemController.swift
@@ -194,7 +194,7 @@ private extension StatusItemController {
 
     func updateStatusItemImage() {
         guard let statusItem = statusItem else { return }
-        statusItem.button?.image = {
+        let image: NSImage? = {
             switch flowStatus {
             case .notConnected, .gettingServerInfo, .gettingProfiles, .configuring:
                 return shouldUseColorIcons ?
@@ -210,6 +210,8 @@ private extension StatusItemController {
                     NSImage(named: "StatusItemGrayscaleConnected")
             }
         }()
+        image?.isTemplate = !shouldUseColorIcons
+        statusItem.button?.image = image
     }
 }
 

--- a/EduVPN/Helpers/CertificateExpiryHelper.swift
+++ b/EduVPN/Helpers/CertificateExpiryHelper.swift
@@ -179,11 +179,10 @@ extension CertificateExpiryHelper.CertificateStatus {
 
     var shouldShowRenewSessionButton: Bool {
         switch self {
-        case .validFor(let timeRemaining, let canRenew):
-            // Show renewal button if session expires in
-            // less than a week. But don't show it in the
-            // first 30 mins after authenticating.
-            return canRenew && timeRemaining < (60 * 60 * 24 * 7)
+        case .validFor(_, let canRenew):
+            // Don't show renewal button in the first 30 mins after authenticating.
+            // Show it all other times.
+            return canRenew
         case .expired:
             return true
         }


### PR DESCRIPTION
Fixes #436.

When setting a grayscale status item image, we should be using the image in template mode.