### PR TITLE
Improve session expiry notifications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Update TunnelKit
   - Use TunnelKit as Swift Package Manager package
   - Avoid writing client certificate and private key to disk
+- Notify on session expiry #442
+- Avoid staggered alerts related to session expiry #445
 
 ## 2.2.4
 

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -85,15 +85,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.activate(ignoringOtherApps: true)
         }
 
-        _ = NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didWakeNotification, object: nil,
-            queue: OperationQueue.main) { _ in
-            if let connectionVC = self.mainViewController?.currentConnectionVC {
-                self.environment?.notificationService.showSessionExpiryAlertOnDeviceWakeUp(
-                    connectionVC: connectionVC)
-            }
-        }
-
         self.mainWindow = window
     }
 

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -546,6 +546,52 @@ private extension ConnectionViewController {
         }
     }
 
+    private func showSessionExpiredAlert() {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        let dateString = formatter.string(from: Date())
+
+        let alertTitle = NSLocalizedString("Your VPN session has expired", comment: "alert title")
+        let alertDetail = NSLocalizedString("Session expired at \(dateString)", comment: "alert detail")
+
+        #if os(macOS)
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = alertTitle
+        alert.informativeText = alertDetail
+        alert.addButton(withTitle: NSLocalizedString("Renew Session", comment: "button title"))
+        alert.addButton(withTitle: NSLocalizedString("Ignore", comment: "button title"))
+        if let window = self.view.window {
+            NSApp.activate(ignoringOtherApps: true)
+            alert.beginSheetModal(for: window) { result in
+                if case .alertFirstButtonReturn = result {
+                    self.renewSession()
+                }
+            }
+        }
+
+        #elseif os(iOS)
+
+        let alert = UIAlertController()
+        alert.title = alertTitle
+        alert.message = alertDetail
+        let refreshAction = UIAlertAction(
+            title: NSLocalizedString("Renew Session", comment: "button title"),
+            style: .default,
+            handler: { _ in
+                self.renewSession()
+            })
+        let cancelAction = UIAlertAction(
+            title: NSLocalizedString("Ignore", comment: "button title"),
+            style: .cancel)
+        alert.addAction(refreshAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true, completion: nil)
+
+        #endif
+    }
 }
 
 extension ConnectionViewController: ConnectionViewModelDelegate {
@@ -833,6 +879,10 @@ extension ConnectionViewController: ConnectionViewModelDelegate {
             self.promptForConnectionTimeVPNConfigPassword(credentials: credentials)
         }
         #endif
+    }
+
+    func connectionViewModelSessionExpired(_ model: ConnectionViewModel) {
+        showSessionExpiredAlert()
     }
 }
 

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -142,6 +142,7 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
 
     #if os(macOS)
     var presentedPasswordEntryVC: PasswordEntryViewController?
+    var isSessionExpiryAlertBeingShown: Bool = false
     #endif
 
     func initializeParameters(_ parameters: Parameters) {
@@ -565,9 +566,13 @@ private extension ConnectionViewController {
         alert.addButton(withTitle: NSLocalizedString("Ignore", comment: "button title"))
         if let window = self.view.window {
             NSApp.activate(ignoringOtherApps: true)
-            alert.beginSheetModal(for: window) { result in
-                if case .alertFirstButtonReturn = result {
-                    self.renewSession()
+            if !isSessionExpiryAlertBeingShown {
+                isSessionExpiryAlertBeingShown = true
+                alert.beginSheetModal(for: window) { result in
+                    self.isSessionExpiryAlertBeingShown = false
+                    if case .alertFirstButtonReturn = result {
+                        self.renewSession()
+                    }
                 }
             }
         }

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -369,6 +369,10 @@ final class ConnectionViewController: ViewController, ParametrizedViewController
     func goBack() {
         parameters.environment.navigationController?.popViewController(animated: true)
     }
+
+    func showSessionAboutToExpireAlert() {
+        showSessionExpiryAlert(afterDelay: true)
+    }
 }
 
 #if os(iOS)
@@ -568,7 +572,8 @@ private extension ConnectionViewController {
 
     // swiftlint:disable:next function_body_length
     private func showSessionExpiryAlert(afterDelay isDelayed: Bool = false) {
-
+        // Shows either session-about-to-expire alert, or the session-has-expired alert
+        // depending on the current time, and the expiry time.
         guard let expiryDate = sessionExpiresAt else {
             // Maybe there's no active eduVPN server VPN connection.
             // Nothing to do.

--- a/EduVPN/Controllers/ConnectionViewController.swift
+++ b/EduVPN/Controllers/ConnectionViewController.swift
@@ -662,7 +662,7 @@ private extension ConnectionViewController {
             alert.addAction(cancelAction)
             if !self.isSessionExpiryAlertBeingShown {
                 self.isSessionExpiryAlertBeingShown = true
-                present(alert, animated: true, completion: nil)
+                self.present(alert, animated: true, completion: nil)
             }
 
             #endif

--- a/EduVPN/Controllers/Mac/PreferencesViewController.swift
+++ b/EduVPN/Controllers/Mac/PreferencesViewController.swift
@@ -81,7 +81,7 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
         let mainVC = parameters.mainVC
         if isSessionExpiryNotificationChecked {
             firstly {
-                notificationService.enableSessionExpiryNotification(from: self)
+                notificationService.enableSessionExpiryNotifications(from: self)
             }.done { isEnabled in
                 if isEnabled {
                     mainVC.scheduleSessionExpiryNotificationOnActiveVPN()
@@ -91,8 +91,8 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
                 }
             }
         } else {
-            notificationService.disableSessionExpiryNotification()
-            notificationService.descheduleSessionExpiryNotification()
+            notificationService.disableSessionExpiryNotifications()
+            notificationService.descheduleSessionExpiryNotifications()
         }
     }
 

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -267,7 +267,7 @@ extension MainViewController: ConnectionServiceInitializationDelegate {
 
         case .vpnDisabled:
             environment.persistenceService.removeLastConnectionAttempt()
-            environment.notificationService.descheduleSessionExpiryNotification()
+            environment.notificationService.descheduleSessionExpiryNotifications()
         }
     }
 }

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -280,6 +280,10 @@ extension MainViewController: NotificationServiceDelegate {
             shouldRenewSessionWhenConnectionServiceInitialized = true
         }
     }
+
+    func notificationServiceSuppressedSessionAboutToExpireNotification(_ notificationService: NotificationService) {
+        currentConnectionVC?.showSessionAboutToExpireAlert()
+    }
 }
 
 extension MainViewController {

--- a/EduVPN/Controllers/iOS/SettingsViewController.swift
+++ b/EduVPN/Controllers/iOS/SettingsViewController.swift
@@ -67,7 +67,7 @@ class SettingsViewController: UITableViewController, ParametrizedViewController 
         let mainVC = parameters.mainVC
         if isSessionExpiryNotificationChecked {
             firstly {
-                notificationService.enableSessionExpiryNotification(from: self)
+                notificationService.enableSessionExpiryNotifications(from: self)
             }.done { isEnabled in
                 if isEnabled {
                     mainVC.scheduleSessionExpiryNotificationOnActiveVPN()
@@ -77,8 +77,8 @@ class SettingsViewController: UITableViewController, ParametrizedViewController 
                 }
             }
         } else {
-            notificationService.disableSessionExpiryNotification()
-            notificationService.descheduleSessionExpiryNotification()
+            notificationService.disableSessionExpiryNotifications()
+            notificationService.descheduleSessionExpiryNotifications()
         }
     }
 

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -584,13 +584,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2611" height="60"/>
+                                <rect key="frame" x="20" y="20" width="2662" height="74"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2611" height="60"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2662" height="74"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2611" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2662" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -819,11 +819,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="327" width="90" height="479"/>
+                                        <rect key="frame" x="195" y="341" width="90" height="465"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="282" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="296" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -831,7 +831,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="230" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="244" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -845,12 +845,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="186" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="200" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="5" y="0.0" width="470" height="174"/>
+                                        <rect key="frame" x="5" y="0.0" width="470" height="188"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="470" height="174"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="470" height="188"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">
@@ -1601,7 +1601,7 @@ Gw
                                     </button>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Oi4-NS-aHo" userLabel="Notification info">
                                         <rect key="frame" x="18" y="339" width="394" height="36"/>
-                                        <textFieldCell key="cell" selectable="YES" title="If enabled, a notification is triggered 30 mins before session expiry." id="Xc0-6z-lDX">
+                                        <textFieldCell key="cell" selectable="YES" title="If enabled, a notification is triggered 30 mins before session expiry, and when the session expires." id="Xc0-6z-lDX">
                                             <font key="font" size="13" name="OpenSans-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -420,7 +420,7 @@ CA
                                 <rect key="frame" x="10" y="520" width="400" height="60"/>
                                 <subviews>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="PNs-Y1-pKE" userLabel="Toolbar Logo View">
-                                        <rect key="frame" x="133" y="12" width="135" height="40"/>
+                                        <rect key="frame" x="-20" y="12" width="440" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="R6d-kC-jEw"/>
                                         </constraints>
@@ -584,13 +584,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2662" height="74"/>
+                                <rect key="frame" x="20" y="20" width="2696" height="54"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2662" height="74"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2696" height="54"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2662" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2696" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -819,11 +819,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="341" width="90" height="465"/>
+                                        <rect key="frame" x="195" y="321" width="90" height="485"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="296" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="276" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -831,7 +831,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="244" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="224" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -845,12 +845,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="200" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="180" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="5" y="0.0" width="470" height="188"/>
+                                        <rect key="frame" x="5" y="0.0" width="470" height="168"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="470" height="188"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="470" height="168"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">
@@ -1601,7 +1601,7 @@ Gw
                                     </button>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Oi4-NS-aHo" userLabel="Notification info">
                                         <rect key="frame" x="18" y="339" width="394" height="36"/>
-                                        <textFieldCell key="cell" selectable="YES" title="If enabled, a notification is triggered 30 mins before session expiry, and when the session expires." id="Xc0-6z-lDX">
+                                        <textFieldCell key="cell" selectable="YES" title="If enabled, a notification is triggered 1 hour before session expiry, and when the session expires." id="Xc0-6z-lDX">
                                             <font key="font" size="13" name="OpenSans-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1648,7 +1648,7 @@ Gw
                                         <rect key="frame" x="0.0" y="237" width="256" height="20"/>
                                         <subviews>
                                             <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BB1-ZH-rOd">
-                                                <rect key="frame" x="-2" y="0.0" width="161" height="20"/>
+                                                <rect key="frame" x="-2" y="1" width="161" height="19"/>
                                                 <buttonCell key="cell" type="check" title="Show in menu bar in" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vXs-mm-f1r">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" size="14" name="OpenSans-Regular"/>

--- a/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZYg-AK-nsP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZYg-AK-nsP">
     <device id="retina3_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -47,7 +47,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="SimpleServerRowCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="SimpleServerRowCell" textLabel="0Ga-3K-NHd" style="IBUITableViewCellStyleDefault" id="1Rn-Wb-SQS" userLabel="Simple Server Row" customClass="RowCell" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="24.5" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1Rn-Wb-SQS" id="lbc-5P-EyC">
                                             <rect key="frame" x="0.0" y="0.0" width="294.5" height="43.5"/>
@@ -64,7 +64,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="SecureInternetServerRowCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="SecureInternetServerRowCell" textLabel="6lP-sE-d7n" style="IBUITableViewCellStyleDefault" id="bC2-3r-MxZ" userLabel="Secure Internet Server Row" customClass="RowCell" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="68" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="88" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bC2-3r-MxZ" id="2jy-Oe-ZL9">
                                             <rect key="frame" x="0.0" y="0.0" width="294.5" height="43.5"/>
@@ -81,21 +81,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MainSectionHeaderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MainSectionHeaderCell" id="yMb-As-UNX" userLabel="Main Section Header" customClass="SectionHeaderCell" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="111.5" width="320" height="78.5"/>
+                                        <rect key="frame" x="0.0" y="131.5" width="320" height="78"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yMb-As-UNX" id="8ZY-UX-jMB">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xfu-EH-waX">
-                                                    <rect key="frame" x="20" y="32.5" width="30" height="30"/>
+                                                    <rect key="frame" x="20" y="32" width="30" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="Ixp-iu-5x5"/>
                                                         <constraint firstAttribute="width" constant="30" id="nD7-IE-tTs"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ayi-Q2-5Y0">
-                                                    <rect key="frame" x="60" y="35" width="244" height="28.5"/>
+                                                    <rect key="frame" x="60" y="35" width="244" height="28"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="20"/>
                                                     <color key="textColor" name="BoldUITextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -116,27 +116,27 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MainSecureInternetSectionHeaderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MainSecureInternetSectionHeaderCell" id="qaR-jP-1W0" userLabel="Main Secure Internet Section Header" customClass="MainSecureInternetSectionHeaderCell" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="190" width="320" height="78.5"/>
+                                        <rect key="frame" x="0.0" y="209.5" width="320" height="78"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qaR-jP-1W0" id="J6y-9a-9Oo">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cGD-Wn-if5">
-                                                    <rect key="frame" x="20" y="32.5" width="30" height="30"/>
+                                                    <rect key="frame" x="20" y="32" width="30" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="30" id="Cxl-ns-Wpr"/>
                                                         <constraint firstAttribute="height" constant="30" id="ddT-D0-vqc"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rfe-gF-Wx9">
-                                                    <rect key="frame" x="60" y="35" width="108" height="28.5"/>
+                                                    <rect key="frame" x="60" y="35" width="108" height="28"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="20"/>
                                                     <color key="textColor" name="BoldUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eUM-71-kHR">
-                                                    <rect key="frame" x="178" y="37" width="116" height="30"/>
+                                                    <rect key="frame" x="178" y="36.5" width="116" height="30"/>
                                                     <state key="normal" title="Change Location"/>
                                                     <connections>
                                                         <action selector="changeLocationTapped:" destination="qaR-jP-1W0" eventType="touchUpInside" id="7T7-A2-aug"/>
@@ -239,7 +239,7 @@
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <prototypes>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchRowCell" textLabel="G3K-Yo-Vb7" style="IBUITableViewCellStyleDefault" id="jg4-Se-j3E" userLabel="Search Row" customClass="RowCell" customModule="eduVPN" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="24.5" width="320" height="43.5"/>
+                                                        <rect key="frame" x="0.0" y="44.5" width="320" height="43.5"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="jg4-Se-j3E" id="2xW-0m-s1H">
                                                             <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
@@ -256,7 +256,7 @@
                                                         </tableViewCellContentView>
                                                     </tableViewCell>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MainSectionHeaderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchSectionHeaderCell" id="51I-6k-mhR" userLabel="Search Section Header" customClass="SectionHeaderCell" customModule="eduVPN" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="68" width="320" height="78"/>
+                                                        <rect key="frame" x="0.0" y="88" width="320" height="78"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="51I-6k-mhR" id="cia-KD-gGj">
                                                             <rect key="frame" x="0.0" y="0.0" width="320" height="78"/>
@@ -291,14 +291,14 @@
                                                         </connections>
                                                     </tableViewCell>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchNoResultsCell" textLabel="p7f-Cm-ntA" style="IBUITableViewCellStyleDefault" id="UGc-9h-dOK" userLabel="Search No Results" customClass="SearchNoResultsCell" customModule="eduVPN" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="146" width="320" height="43.5"/>
+                                                        <rect key="frame" x="0.0" y="166" width="320" height="44"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UGc-9h-dOK" id="zj5-6d-z9M">
-                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="No results. Please check your search query." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="p7f-Cm-ntA">
-                                                                    <rect key="frame" x="16" y="0.0" width="288" height="43.5"/>
+                                                                    <rect key="frame" x="8" y="0.0" width="304" height="44"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                                     <color key="textColor" name="RegularUITextColor"/>
@@ -700,7 +700,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ItemSelectionCell" textLabel="jBQ-g6-fH8" style="IBUITableViewCellStyleDefault" id="r3h-Uu-kk8">
-                                <rect key="frame" x="0.0" y="24.5" width="320" height="44.5"/>
+                                <rect key="frame" x="0.0" y="44.5" width="320" height="44.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r3h-Uu-kk8" id="ESh-G5-bD1">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="44.5"/>
@@ -737,7 +737,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ConnectionInfoCell" rowHeight="78" id="cUW-x0-2CU" userLabel="Connection Info Cell" customClass="ConnectionInfoCell" customModule="eduVPN" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="24.5" width="320" height="78"/>
+                                <rect key="frame" x="0.0" y="44.5" width="320" height="78"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cUW-x0-2CU" id="LHB-xm-ZMQ">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="78"/>
@@ -824,7 +824,7 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="Notifications" footerTitle="If enabled, a notification is triggered 30 mins before session expiry." id="3s3-yP-DD1">
+                            <tableViewSection headerTitle="Notifications" footerTitle="If enabled, a notification is triggered 30 mins before session expiry, and when the session expires." id="3s3-yP-DD1">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="VZ3-o9-efz">
                                         <rect key="frame" x="0.0" y="187" width="320" height="43.5"/>
@@ -860,7 +860,7 @@
                             <tableViewSection headerTitle="Logging" id="UOS-N7-Rcv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="ybG-3O-5od">
-                                        <rect key="frame" x="0.0" y="303" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="317" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ybG-3O-5od" id="84I-6v-Tn8">
                                             <rect key="frame" x="0.0" y="0.0" width="294.5" height="43.5"/>
@@ -881,7 +881,7 @@
                             <tableViewSection headerTitle="Import" id="RsF-JL-0Za">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="JVz-gK-yTg">
-                                        <rect key="frame" x="0.0" y="396.5" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="410.5" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JVz-gK-yTg" id="ppR-Rf-pES">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
@@ -906,10 +906,10 @@
                             <tableViewSection headerTitle="About" footerTitle="For license information, please see the source code." id="zZ8-eL-KFl">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="clE-jt-jh6" detailTextLabel="6Vz-Gx-mbB" style="IBUITableViewCellStyleValue1" id="2bw-6y-6xS">
-                                        <rect key="frame" x="0.0" y="497.5" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="511.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2bw-6y-6xS" id="gCV-zU-1zY">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="clE-jt-jh6">
@@ -930,20 +930,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Zsk-gl-9Hv" detailTextLabel="AyI-A2-tvn" style="IBUITableViewCellStyleValue1" id="4tU-D4-oc1">
-                                        <rect key="frame" x="0.0" y="541" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="555.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4tU-D4-oc1" id="8ys-ct-SxW">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Source code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zsk-gl-9Hv">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Source code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zsk-gl-9Hv">
                                                     <rect key="frame" x="16" y="11" width="92" height="22"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="https://github.com/eduvpn/apple" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" id="AyI-A2-tvn">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="https://github.com/eduvpn/apple" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" id="AyI-A2-tvn">
                                                     <rect key="frame" x="114" y="11" width="190" height="22"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
@@ -1222,7 +1222,7 @@
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="RegularUITextColor">
-            <color red="0.31372549019607843" green="0.31372549019607843" blue="0.31372549019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.31400001049041748" green="0.31400001049041748" blue="0.31400001049041748" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
@@ -23,7 +23,7 @@
             <objects>
                 <navigationController id="ZYg-AK-nsP" customClass="NavigationController" customModule="eduVPN" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="TzF-nK-Efm">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -801,7 +801,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connect using TCP only" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Axm-hd-YwD">
-                                                    <rect key="frame" x="16" y="11" width="225" height="22"/>
+                                                    <rect key="frame" x="16" y="12.5" width="225" height="19"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -824,7 +824,7 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="Notifications" footerTitle="If enabled, a notification is triggered 30 mins before session expiry, and when the session expires." id="3s3-yP-DD1">
+                            <tableViewSection headerTitle="Notifications" footerTitle="If enabled, a notification is triggered 1 hour before session expiry, and when the session expires." id="3s3-yP-DD1">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="VZ3-o9-efz">
                                         <rect key="frame" x="0.0" y="187" width="320" height="43.5"/>
@@ -834,7 +834,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Notify before session expiry" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HSr-1W-y5a">
-                                                    <rect key="frame" x="16" y="11" width="225" height="22"/>
+                                                    <rect key="frame" x="16" y="12.5" width="225" height="19"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -860,7 +860,7 @@
                             <tableViewSection headerTitle="Logging" id="UOS-N7-Rcv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="ybG-3O-5od">
-                                        <rect key="frame" x="0.0" y="317" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="303" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ybG-3O-5od" id="84I-6v-Tn8">
                                             <rect key="frame" x="0.0" y="0.0" width="294.5" height="43.5"/>
@@ -881,7 +881,7 @@
                             <tableViewSection headerTitle="Import" id="RsF-JL-0Za">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="JVz-gK-yTg">
-                                        <rect key="frame" x="0.0" y="410.5" width="320" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="396.5" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JVz-gK-yTg" id="ppR-Rf-pES">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
@@ -906,21 +906,21 @@
                             <tableViewSection headerTitle="About" footerTitle="For license information, please see the source code." id="zZ8-eL-KFl">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="clE-jt-jh6" detailTextLabel="6Vz-Gx-mbB" style="IBUITableViewCellStyleValue1" id="2bw-6y-6xS">
-                                        <rect key="frame" x="0.0" y="511.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="497.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2bw-6y-6xS" id="gCV-zU-1zY">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="clE-jt-jh6">
-                                                    <rect key="frame" x="16" y="11" width="76.5" height="22"/>
+                                                    <rect key="frame" x="16" y="13" width="74" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Version number" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6Vz-Gx-mbB">
-                                                    <rect key="frame" x="183.5" y="11" width="120.5" height="22"/>
+                                                    <rect key="frame" x="192" y="13" width="112" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
@@ -930,21 +930,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Zsk-gl-9Hv" detailTextLabel="AyI-A2-tvn" style="IBUITableViewCellStyleValue1" id="4tU-D4-oc1">
-                                        <rect key="frame" x="0.0" y="555.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="541.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4tU-D4-oc1" id="8ys-ct-SxW">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Source code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zsk-gl-9Hv">
-                                                    <rect key="frame" x="16" y="11" width="92" height="22"/>
+                                                    <rect key="frame" x="16" y="13" width="91" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="https://github.com/eduvpn/apple" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" id="AyI-A2-tvn">
-                                                    <rect key="frame" x="114" y="11" width="190" height="22"/>
+                                                    <rect key="frame" x="113" y="13" width="191" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" systemColor="systemBlueColor"/>

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -53,7 +53,7 @@ class NotificationService: NSObject {
         }
     }
 
-    func attemptSchedulingSessionExpiryNotification(
+    func attemptSchedulingSessionExpiryNotifications(
         expiryDate: Date, authenticationDate: Date?, connectionAttemptId: UUID, from viewController: ViewController) -> Guarantee<Bool> {
 
         let userDefaults = UserDefaults.standard
@@ -67,7 +67,7 @@ class NotificationService: NSObject {
                 .then { isUserWantsToBeNotified in
                     UserDefaults.standard.hasAskedUserOnNotifyBeforeSessionExpiry = true
                     if isUserWantsToBeNotified {
-                        return self.scheduleSessionExpiryNotification(
+                        return self.scheduleSessionExpiryNotifications(
                             expiryDate: expiryDate, authenticationDate: authenticationDate,
                             connectionAttemptId: connectionAttemptId)
                             .map { isAuthorized in
@@ -84,7 +84,7 @@ class NotificationService: NSObject {
         } else if userDefaults.shouldNotifyBeforeSessionExpiry {
             // User has chosen to be notified.
             // Attempt to schedule notification.
-            return scheduleSessionExpiryNotification(
+            return scheduleSessionExpiryNotifications(
                 expiryDate: expiryDate, authenticationDate: authenticationDate,
                 connectionAttemptId: connectionAttemptId)
         } else {
@@ -94,12 +94,12 @@ class NotificationService: NSObject {
         }
     }
 
-    func scheduleSessionExpiryNotification(
+    func scheduleSessionExpiryNotifications(
         expiryDate: Date, authenticationDate: Date?, connectionAttemptId: UUID) -> Guarantee<Bool> {
         return Self.requestAuthorization()
             .then { isAuthorized in
                 if isAuthorized {
-                    return Self.scheduleSessionExpiryNotification(
+                    return Self.scheduleSessionExpiryNotifications(
                         expiryDate: expiryDate, authenticationDate: authenticationDate,
                         connectionAttemptId: connectionAttemptId)
                 } else {
@@ -109,12 +109,12 @@ class NotificationService: NSObject {
             }
     }
 
-    func descheduleSessionExpiryNotification() {
+    func descheduleSessionExpiryNotifications() {
         Self.notificationCenter.removeAllPendingNotificationRequests()
         os_log("Certificate expiry notifications descheduled", log: Log.general, type: .debug)
     }
 
-    func enableSessionExpiryNotification(from viewController: ViewController) -> Guarantee<Bool> {
+    func enableSessionExpiryNotifications(from viewController: ViewController) -> Guarantee<Bool> {
         firstly {
             Self.requestAuthorization()
         }.map { isAuthorized in
@@ -128,7 +128,7 @@ class NotificationService: NSObject {
         }
     }
 
-    func disableSessionExpiryNotification() {
+    func disableSessionExpiryNotifications() {
         UserDefaults.standard.shouldNotifyBeforeSessionExpiry = false
     }
 
@@ -268,7 +268,7 @@ class NotificationService: NSObject {
         #endif
     }
 
-    private static func scheduleSessionExpiryNotification(
+    private static func scheduleSessionExpiryNotifications(
         expiryDate: Date, authenticationDate: Date?, connectionAttemptId: UUID) -> Guarantee<Bool> {
 
         os_log("Certificate expires at %{public}@", log: Log.general, type: .debug, expiryDate as NSDate)

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -299,7 +299,7 @@ class NotificationService: NSObject {
             }
         }()
 
-        let secondsTillHasExpiredNotification = max(secondsToExpiry, 5)
+        let secondsTillHasExpiredNotification = max(secondsToExpiry, 0) + 2
 
         precondition(secondsTillAboutToExpireNotification > 0)
         precondition(secondsTillHasExpiredNotification > 0)
@@ -498,6 +498,14 @@ extension NotificationService: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.alert, .sound])
+        if notification.request.identifier == Self.sessionAboutToExpireNotificationId {
+            if #available(macOS 11.0, iOS 14.0, *) {
+                completionHandler([.list, .banner])
+            } else {
+                completionHandler([.alert, .sound])
+            }
+        } else {
+            completionHandler([])
+        }
     }
 }

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -445,11 +445,11 @@ extension NotificationService: UNUserNotificationCenterDelegate {
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         if notification.request.identifier == Self.sessionAboutToExpireNotificationId {
-            if #available(macOS 11.0, iOS 14.0, *) {
-                completionHandler([.list, .banner])
-            } else {
+            // if #available(macOS 11.0, iOS 14.0, *) {
+            //     completionHandler([.list, .banner])
+            // } else {
                 self.delegate?.notificationServiceSuppressedSessionAboutToExpireNotification(self)
-            }
+            // }
         } else {
             completionHandler([])
         }

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -29,7 +29,7 @@ class NotificationService: NSObject {
         UNUserNotificationCenter.current()
     }
 
-    private static let sessionExpiryNotificationId = "SessionExpiryNotification"
+    private static let sessionAboutToExpireNotificationId = "SessionAboutToExpireNotification"
     private static let authorizationOptions: UNAuthorizationOptions = [.alert, .sound]
 
     override init() {
@@ -331,7 +331,7 @@ class NotificationService: NSObject {
         content.categoryIdentifier = NotificationCategory.certificateExpiry.rawValue
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(secondsToNotification), repeats: false)
-        let request = UNNotificationRequest(identifier: sessionExpiryNotificationId, content: content, trigger: trigger)
+        let request = UNNotificationRequest(identifier: sessionAboutToExpireNotificationId, content: content, trigger: trigger)
 
         return Guarantee<Bool> { callback in
             notificationCenter.add(request) { error in
@@ -363,7 +363,7 @@ extension NotificationService {
                 return
             }
 
-            if requests.contains(where: { $0.identifier == Self.sessionExpiryNotificationId }) {
+            if requests.contains(where: { $0.identifier == Self.sessionAboutToExpireNotificationId }) {
                 // Notification is yet to appear.
                 // No need to show any alert on device wakeup.
                 return

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -508,4 +508,4 @@ extension NotificationService: UNUserNotificationCenterDelegate {
             completionHandler([])
         }
     }
-}
+} // swiftlint:disable:this file_length

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -290,8 +290,9 @@ class NotificationService: NSObject {
 
         let secondsTillAboutToExpireNotification: Int = {
             if minutesTillAboutToExpireNotification >= minutesToExpiry {
-                os_log("Scheduling 'Session about to expire' notification to fire 5 seconds after expiry")
-                return secondsToExpiry + 5 // 5 seconds after expiry
+                let halfTime = (secondsToExpiry / 2) + 1
+                os_log("Scheduling 'Session about to expire' notification to fire in %{public}d seconds even though browser auth might not have expired by then because we assume this is a test server.", log: Log.general, type: .debug, halfTime)
+                return halfTime
             } else if minutesTillAboutToExpireNotification < 0 {
                 os_log("Scheduling 'Session about to expire' notification to fire 5 seconds from now")
                 return 5 // 5 seconds from now

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -10,6 +10,7 @@ import PromiseKit
 import os.log
 
 protocol NotificationServiceDelegate: AnyObject {
+    func notificationServiceSuppressedSessionAboutToExpireNotification(_ notificationService: NotificationService)
     func notificationServiceDidReceiveRenewSessionRequest(_ notificationService: NotificationService)
 }
 
@@ -446,7 +447,7 @@ extension NotificationService: UNUserNotificationCenterDelegate {
             if #available(macOS 11.0, iOS 14.0, *) {
                 completionHandler([.list, .banner])
             } else {
-                completionHandler([.alert, .sound])
+                self.delegate?.notificationServiceSuppressedSessionAboutToExpireNotification(self)
             }
         } else {
             completionHandler([])

--- a/EduVPN/Services/NotificationService.swift
+++ b/EduVPN/Services/NotificationService.swift
@@ -278,14 +278,14 @@ class NotificationService: NSObject {
         let secondsToExpiry = Calendar.current.dateComponents([.second], from: Date(), to: expiryDate).second ?? 0
 
         let minutesTillAboutToExpireNotification: Int = {
-            // normalNotificationTime is 30 mins before expiry
-            let normalNotificationTime = minutesToExpiry - 30
+            // normalNotificationTime is 1 hour before expiry
+            let normalNotificationTime = minutesToExpiry - 60
             guard let authenticationDate = authenticationDate,
                   let minutesFromAuthTime = Calendar.current.dateComponents([.minute], from: authenticationDate, to: Date()).minute else {
                       return normalNotificationTime
                   }
             os_log("Last authenticated %{public}d minutes back", log: Log.general, type: .debug, minutesFromAuthTime)
-            // 30 mins before expiry, but should be at least 32 mins since auth time
+            // 1 hour before expiry, but should be at least 32 mins since auth time
             let afterBrowserSessionExpires = 30 /* browser session time */ - 2 /* buffer */ - minutesFromAuthTime
             return max(normalNotificationTime, afterBrowserSessionExpires)
         }()

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -45,6 +45,8 @@ protocol ConnectionViewModelDelegate: AnyObject {
     func connectionViewModel(
         _ model: ConnectionViewModel,
         didBeginConnectingWithCredentials credentials: Credentials?, shouldAskForPassword: Bool)
+    func connectionViewModelSessionExpired(
+        _ model: ConnectionViewModel)
 }
 
 class ConnectionViewModel { // swiftlint:disable:this type_body_length
@@ -190,9 +192,17 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
     }
 
     private var sessionStatus: SessionExpiryHelper.SessionStatus? {
-        didSet {
+        didSet(oldValue) {
             self.updateStatusDetail()
             self.updateAdditionalControl()
+            if let newValue = sessionStatus, let oldValue = oldValue {
+                switch (oldValue, newValue) {
+                case (.validFor, .expired):
+                    self.delegate?.connectionViewModelSessionExpired(self)
+                default:
+                    break
+                }
+            }
         }
     }
 

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -460,7 +460,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
             guard let notificationService = self.notificationService else {
                 return Promise.value(())
             }
-            return notificationService.attemptSchedulingSessionExpiryNotification(
+            return notificationService.attemptSchedulingSessionExpiryNotifications(
                 expiryDate: expiresAt, authenticationDate: authenticatedAt,
                 connectionAttemptId: connectionAttemptId, from: viewController)
                 .map { _ in }
@@ -523,7 +523,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
             self.internalState = .disableVPNRequested
             return self.connectionService.disableVPN()
         }.then { () -> Promise<Void> in
-            self.notificationService?.descheduleSessionExpiryNotification()
+            self.notificationService?.descheduleSessionExpiryNotifications()
             if let serverInfoForDisconnectReport = self.serverInfoForDisconnectReport,
                let profile = self.connectingProfile,
                let serverAPIService = self.serverAPIService {
@@ -580,7 +580,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
         if let connectionAttemptId = connectionService.connectionAttemptId,
            let expiryDate = sessionExpiryHelper?.expiresAt,
            let notificationService = notificationService {
-            return notificationService.scheduleSessionExpiryNotification(
+            return notificationService.scheduleSessionExpiryNotifications(
                 expiryDate: expiryDate,
                 authenticationDate: sessionExpiryHelper?.authenticatedAt,
                 connectionAttemptId: connectionAttemptId)


### PR DESCRIPTION
This PR does the following:

1. Show notification when session has expired
2. If the app is in the foreground when (a) session is about to expire in 30 mins, or (b) session expires, or (c) when device wakes up and (a) or (b) is true, we show an alert instead of a notification
3. Since (2) above can result in multiple alerts, we keep track of whether a previous session-expiry-related alert is being shown or not. We show an alert only if another is not already being shown undismissed.

Fixes #442 and #445.
