### PR TITLE
Fix usage of API v3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- APIv3: Use prefer_tcp, fix accept header for '/connect'
+
 ## 3.0.0
 
 - Support for minisign pre-hashed signatures #427

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -204,7 +204,7 @@ private extension ServerAPIv3Handler {
                     parameters: [
                         "profile_id": profile.profileId,
                         "public_key": publicKey,
-                        "tcp_only": isTCPOnly ? "on" : "off"
+                        "prefer_tcp": isTCPOnly ? "yes" : "no"
                     ],
                     encoding: URLEncoding.httpBody)
             }

--- a/EduVPN/Networking/ServerAPIv3Handler.swift
+++ b/EduVPN/Networking/ServerAPIv3Handler.swift
@@ -166,7 +166,7 @@ struct ServerAPIv3Handler: ServerAPIHandler {
 }
 
 private extension ServerAPIv3Handler {
-    enum ServerAPITarget: TargetType, AcceptJson, AccessTokenAuthorizable {
+    enum ServerAPITarget: TargetType, AccessTokenAuthorizable {
         case info(ServerAPIService.CommonAPIRequestInfo)
         case connect(ServerAPIService.CommonAPIRequestInfo, profile: Profile, publicKey: String, isTCPOnly: Bool)
 
@@ -207,6 +207,15 @@ private extension ServerAPIv3Handler {
                         "prefer_tcp": isTCPOnly ? "yes" : "no"
                     ],
                     encoding: URLEncoding.httpBody)
+            }
+        }
+
+        var headers: [String: String]? {
+            switch self {
+            case .info:
+                return ["Accept": "application/json"]
+            case .connect:
+                return ["Accept": "application/x-openvpn-profile, application/x-wireguard-profile"]
             }
         }
 


### PR DESCRIPTION
- Use prefer_tcp instead of tcp_only
- Change accept header for `/connect` from `application/json` to `application/x-openvpn-profile, application/x-wireguard-profile`
