### PR TITLE
Fix typo in oauth confirmation msgbox

### DIFF
--- a/EduVPN/Helpers/Mac/OAuthRedirectHTTPHandler.m
+++ b/EduVPN/Helpers/Mac/OAuthRedirectHTTPHandler.m
@@ -63,7 +63,7 @@ static NSString *const kHTMLPageTemplate = @""
 static NSString *const kStringsAuthorizationComplete[] =
     {
         @"Authorization Successful",
-        @"The client authorized succesfully",
+        @"The client has been authorized successfully",
         @"You can now close this tab."
     };
 


### PR DESCRIPTION
Noticed a typo in the string that is displayed after you've pressed 'authorize' in your web browser.