### PR TITLE
Access privacy statement from settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Show privacy statement on launch #454
+- Allow access to privacy statement from Settings / Preferences
 - Update list of available secure internet servers on startup #447
 - APIv3: Use prefer_tcp, fix accept header for '/connect'
 - Support for net_gateway / net_gateway_ipv6 in OpenVPN #440

--- a/EduVPN/Controllers/Mac/PreferencesViewController.swift
+++ b/EduVPN/Controllers/Mac/PreferencesViewController.swift
@@ -113,6 +113,12 @@ class PreferencesViewController: ViewController, ParametrizedViewController {
         appDelegate.resetAppAfterConfirming()
     }
 
+    @IBAction func viewPrivacyStatementClicked(_ sender: Any) {
+        guard let navigationController = parameters.environment.navigationController else { return }
+        self.presentingViewController?.dismiss(self)
+        navigationController.showDisclaimer(onAccepted: {})
+    }
+
     @IBAction func doneClicked(_ sender: Any) {
         self.presentingViewController?.dismiss(self)
     }

--- a/EduVPN/Controllers/iOS/SettingsViewController.swift
+++ b/EduVPN/Controllers/iOS/SettingsViewController.swift
@@ -108,6 +108,10 @@ extension SettingsViewController {
             return indexPath
         }
         if indexPath.section == 4 && indexPath.row == 1 {
+            // This is a 'Privacy statement' row
+            return indexPath
+        }
+        if indexPath.section == 4 && indexPath.row == 2 {
             // This is a 'Source code' row
             return indexPath
         }
@@ -115,12 +119,18 @@ extension SettingsViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
         if indexPath.section == 2 && indexPath.row == 0 {
             // This is a 'Connection Log' row
             let logVC = parameters.environment.instantiateLogViewController()
             navigationController?.pushViewController(logVC, animated: true)
         }
         if indexPath.section == 4 && indexPath.row == 1 {
+            // This is a 'Privacy statement' row
+            guard let navigationController = parameters.environment.navigationController else { return }
+            navigationController.showDisclaimer(onAccepted: {}, from: self)
+        }
+        if indexPath.section == 4 && indexPath.row == 2 {
             // This is a 'Source code' row
             if let sourceCodeURL = URL(string: "https://github.com/eduvpn/apple") {
                 let safariVC = SFSafariViewController(url: sourceCodeURL)

--- a/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/Mac/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -584,13 +584,13 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ViX-vU-MfI" userLabel="Table Container View">
-                                <rect key="frame" x="20" y="20" width="2696" height="54"/>
+                                <rect key="frame" x="20" y="20" width="2764" height="58"/>
                                 <clipView key="contentView" drawsBackground="NO" id="Vdj-rZ-nzW">
-                                    <rect key="frame" x="0.0" y="0.0" width="2696" height="54"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="2764" height="58"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="0Se-xs-SBR">
-                                            <rect key="frame" x="0.0" y="0.0" width="2696" height="334"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="2764" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="20"/>
                                             <color key="backgroundColor" red="0.92549019610000005" green="0.92549019610000005" blue="0.92549019610000005" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -819,11 +819,11 @@ Gw
                                         </constraints>
                                     </customView>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AiJ-eh-cZR" userLabel="Top Image">
-                                        <rect key="frame" x="195" y="321" width="90" height="485"/>
+                                        <rect key="frame" x="195" y="347" width="90" height="459"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="SearchScreenTopImage" id="oWj-11-tRC"/>
                                     </imageView>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OYQ-UB-7ZA">
-                                        <rect key="frame" x="-2" y="276" width="483" height="33"/>
+                                        <rect key="frame" x="-2" y="302" width="483" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Find your institute" id="eUs-aO-u69">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="BoldUITextColor"/>
@@ -831,7 +831,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <searchField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-dp-amy" customClass="SearchField" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="224" width="479" height="40"/>
+                                        <rect key="frame" x="0.0" y="250" width="479" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="YjK-Nc-dHe"/>
                                         </constraints>
@@ -845,12 +845,12 @@ Gw
                                         </connections>
                                     </searchField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6lv-tg-3Yq" userLabel="Spinner">
-                                        <rect key="frame" x="224" y="180" width="32" height="32"/>
+                                        <rect key="frame" x="224" y="206" width="32" height="32"/>
                                     </progressIndicator>
                                     <scrollView wantsLayer="YES" horizontalHuggingPriority="100" borderType="none" autohidesScrollers="YES" horizontalLineScroll="60" horizontalPageScroll="10" verticalLineScroll="60" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hge-fJ-m1C">
-                                        <rect key="frame" x="5" y="0.0" width="470" height="168"/>
+                                        <rect key="frame" x="5" y="0.0" width="470" height="194"/>
                                         <clipView key="contentView" drawsBackground="NO" id="73u-Eo-EqN">
-                                            <rect key="frame" x="0.0" y="0.0" width="470" height="168"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="470" height="194"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="40" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" id="s7r-dP-3wP">
@@ -1555,10 +1555,10 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yI9-CM-5gZ">
-                                <rect key="frame" x="20" y="20" width="410" height="556"/>
+                                <rect key="frame" x="20" y="20" width="410" height="587"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rjv-VU-vqt">
-                                        <rect key="frame" x="-2" y="523" width="414" height="33"/>
+                                        <rect key="frame" x="-2" y="554" width="414" height="33"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Preferences" id="8ia-lI-dqX">
                                             <font key="font" size="24" name="OpenSans-Bold"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1566,10 +1566,10 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="GMI-07-EVu">
-                                        <rect key="frame" x="0.0" y="508" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="539" width="410" height="5"/>
                                     </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bZ6-la-8zq">
-                                        <rect key="frame" x="-2" y="479" width="179" height="19"/>
+                                        <rect key="frame" x="-2" y="510" width="179" height="19"/>
                                         <buttonCell key="cell" type="check" title="Connect using TCP only" bezelStyle="regularSquare" imagePosition="left" inset="2" id="t0F-zx-2Sp">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1579,18 +1579,15 @@ Gw
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="F1W-bg-sSw" userLabel="UseTCP info">
-                                        <rect key="frame" x="18" y="431" width="394" height="36"/>
+                                        <rect key="frame" x="18" y="462" width="394" height="36"/>
                                         <textFieldCell key="cell" selectable="YES" title="Changes to this option will take effect from the next connection onwards. Applies to OpenVPN connections only." id="rqy-tm-oLB">
                                             <font key="font" size="13" name="OpenSans-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Xq3-ya-gMs">
-                                        <rect key="frame" x="0.0" y="416" width="410" height="5"/>
-                                    </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HMt-Bk-EIQ">
-                                        <rect key="frame" x="-2" y="387" width="300" height="19"/>
+                                        <rect key="frame" x="-2" y="431" width="300" height="19"/>
                                         <buttonCell key="cell" type="check" title="Notify when the session is about to expire" bezelStyle="regularSquare" imagePosition="left" inset="2" id="qUc-Jr-rVi">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1600,7 +1597,7 @@ Gw
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Oi4-NS-aHo" userLabel="Notification info">
-                                        <rect key="frame" x="18" y="339" width="394" height="36"/>
+                                        <rect key="frame" x="18" y="383" width="394" height="36"/>
                                         <textFieldCell key="cell" selectable="YES" title="If enabled, a notification is triggered 1 hour before session expiry, and when the session expires." id="Xc0-6z-lDX">
                                             <font key="font" size="13" name="OpenSans-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1608,10 +1605,10 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="2Ow-MZ-6TT">
-                                        <rect key="frame" x="0.0" y="324" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="368" width="410" height="5"/>
                                     </box>
                                     <customView horizontalHuggingPriority="100" verticalHuggingPriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="HhY-AU-L8g" userLabel="Connect log container">
-                                        <rect key="frame" x="0.0" y="282" width="410" height="32"/>
+                                        <rect key="frame" x="0.0" y="326" width="410" height="32"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="aEb-MM-aWn">
                                                 <rect key="frame" x="-2" y="7" width="326" height="19"/>
@@ -1642,13 +1639,13 @@ Gw
                                         </constraints>
                                     </customView>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="NeP-ch-ODB">
-                                        <rect key="frame" x="0.0" y="267" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="311" width="410" height="5"/>
                                     </box>
                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="5" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Shm-Uu-Maq">
-                                        <rect key="frame" x="0.0" y="237" width="256" height="20"/>
+                                        <rect key="frame" x="0.0" y="281" width="256" height="20"/>
                                         <subviews>
                                             <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BB1-ZH-rOd">
-                                                <rect key="frame" x="-2" y="1" width="161" height="19"/>
+                                                <rect key="frame" x="-2" y="0.0" width="161" height="20"/>
                                                 <buttonCell key="cell" type="check" title="Show in menu bar in" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vXs-mm-f1r">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1684,7 +1681,7 @@ Gw
                                         </customSpacing>
                                     </stackView>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5mk-S8-qPc">
-                                        <rect key="frame" x="-2" y="206" width="114" height="19"/>
+                                        <rect key="frame" x="-2" y="250" width="114" height="19"/>
                                         <buttonCell key="cell" type="check" title="Show in Dock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lxj-3d-HUJ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1693,11 +1690,8 @@ Gw
                                             <action selector="showInDockCheckboxClicked:" target="46m-sg-SJs" id="Obx-6S-VEF"/>
                                         </connections>
                                     </button>
-                                    <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="kvx-08-oca">
-                                        <rect key="frame" x="0.0" y="191" width="410" height="5"/>
-                                    </box>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0ht-iC-Bc3">
-                                        <rect key="frame" x="-2" y="162" width="126" height="19"/>
+                                        <rect key="frame" x="-2" y="219" width="126" height="19"/>
                                         <buttonCell key="cell" type="check" title="Launch at login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="gLp-0o-Odu">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" size="14" name="OpenSans-Regular"/>
@@ -1707,10 +1701,10 @@ Gw
                                         </connections>
                                     </button>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="STQ-ap-m2r">
-                                        <rect key="frame" x="0.0" y="147" width="410" height="5"/>
+                                        <rect key="frame" x="0.0" y="204" width="410" height="5"/>
                                     </box>
                                     <customView horizontalHuggingPriority="100" verticalHuggingPriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="Iiq-Kh-SJK" userLabel="Reset app container">
-                                        <rect key="frame" x="0.0" y="105" width="410" height="32"/>
+                                        <rect key="frame" x="0.0" y="162" width="410" height="32"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="X1G-dU-mU6">
                                                 <rect key="frame" x="-2" y="7" width="319" height="19"/>
@@ -1741,7 +1735,7 @@ Gw
                                         </constraints>
                                     </customView>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="FOI-Vg-y74" userLabel="Reset app info">
-                                        <rect key="frame" x="-2" y="75" width="391" height="18"/>
+                                        <rect key="frame" x="-2" y="132" width="391" height="18"/>
                                         <textFieldCell key="cell" selectable="YES" title="Resetting the app removes all user data and resets preferences." id="4sl-uh-tBn">
                                             <font key="font" size="13" name="OpenSans-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1749,6 +1743,40 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="T0X-0K-YvG">
+                                        <rect key="frame" x="0.0" y="117" width="410" height="5"/>
+                                    </box>
+                                    <customView horizontalHuggingPriority="100" verticalHuggingPriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="LHM-KH-8iK" userLabel="Privacy statement container">
+                                        <rect key="frame" x="0.0" y="75" width="410" height="32"/>
+                                        <subviews>
+                                            <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="GgG-PA-ZGb">
+                                                <rect key="frame" x="-2" y="7" width="352" height="19"/>
+                                                <textFieldCell key="cell" selectable="YES" title="Privacy statement" id="twI-bI-Lms">
+                                                    <font key="font" size="14" name="OpenSans-Regular"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3yO-gX-hn4">
+                                                <rect key="frame" x="351" y="-1" width="64" height="32"/>
+                                                <buttonCell key="cell" type="push" title="View" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="j9l-Vb-8CU">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="viewPrivacyStatementClicked:" target="46m-sg-SJs" id="9Ef-U8-hb9"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="3yO-gX-hn4" firstAttribute="leading" secondItem="GgG-PA-ZGb" secondAttribute="trailing" constant="10" id="0Dp-HD-PUS"/>
+                                            <constraint firstItem="GgG-PA-ZGb" firstAttribute="centerY" secondItem="LHM-KH-8iK" secondAttribute="centerY" id="Kwc-Bv-Lbh"/>
+                                            <constraint firstAttribute="trailing" secondItem="3yO-gX-hn4" secondAttribute="trailing" constant="2" id="Txk-hQ-BCY"/>
+                                            <constraint firstItem="GgG-PA-ZGb" firstAttribute="leading" secondItem="LHM-KH-8iK" secondAttribute="leading" id="XX1-d3-4zO"/>
+                                            <constraint firstItem="3yO-gX-hn4" firstAttribute="centerY" secondItem="LHM-KH-8iK" secondAttribute="centerY" id="YwY-wY-nnY"/>
+                                            <constraint firstAttribute="height" constant="32" id="d8Y-WD-Oos"/>
+                                        </constraints>
+                                    </customView>
+                                    <box horizontalHuggingPriority="100" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="LfA-zZ-NRV">
                                         <rect key="frame" x="0.0" y="60" width="410" height="5"/>
                                     </box>
                                     <customView horizontalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="P7w-qm-Tj1" userLabel="Done container">

--- a/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
+++ b/EduVPN/Resources/iOS/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZYg-AK-nsP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZYg-AK-nsP">
     <device id="retina3_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -23,7 +23,7 @@
             <objects>
                 <navigationController id="ZYg-AK-nsP" customClass="NavigationController" customModule="eduVPN" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="TzF-nK-Efm">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -50,11 +50,11 @@
                                         <rect key="frame" x="0.0" y="44.5" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1Rn-Wb-SQS" id="lbc-5P-EyC">
-                                            <rect key="frame" x="0.0" y="0.0" width="294.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="295.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="0Ga-3K-NHd">
-                                                    <rect key="frame" x="16" y="0.0" width="270.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="271.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
@@ -67,11 +67,11 @@
                                         <rect key="frame" x="0.0" y="88" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bC2-3r-MxZ" id="2jy-Oe-ZL9">
-                                            <rect key="frame" x="0.0" y="0.0" width="294.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="295.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6lP-sE-d7n">
-                                                    <rect key="frame" x="16" y="0.0" width="270.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="271.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
@@ -81,21 +81,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MainSectionHeaderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MainSectionHeaderCell" id="yMb-As-UNX" userLabel="Main Section Header" customClass="SectionHeaderCell" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="131.5" width="320" height="78"/>
+                                        <rect key="frame" x="0.0" y="131.5" width="320" height="78.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yMb-As-UNX" id="8ZY-UX-jMB">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xfu-EH-waX">
-                                                    <rect key="frame" x="20" y="32" width="30" height="30"/>
+                                                    <rect key="frame" x="20" y="32.5" width="30" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="Ixp-iu-5x5"/>
                                                         <constraint firstAttribute="width" constant="30" id="nD7-IE-tTs"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ayi-Q2-5Y0">
-                                                    <rect key="frame" x="60" y="35" width="244" height="28"/>
+                                                    <rect key="frame" x="60" y="35" width="244" height="28.5"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="20"/>
                                                     <color key="textColor" name="BoldUITextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -116,27 +116,27 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MainSecureInternetSectionHeaderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MainSecureInternetSectionHeaderCell" id="qaR-jP-1W0" userLabel="Main Secure Internet Section Header" customClass="MainSecureInternetSectionHeaderCell" customModule="eduVPN" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="209.5" width="320" height="78"/>
+                                        <rect key="frame" x="0.0" y="210" width="320" height="78.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qaR-jP-1W0" id="J6y-9a-9Oo">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="78.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cGD-Wn-if5">
-                                                    <rect key="frame" x="20" y="32" width="30" height="30"/>
+                                                    <rect key="frame" x="20" y="32.5" width="30" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="30" id="Cxl-ns-Wpr"/>
                                                         <constraint firstAttribute="height" constant="30" id="ddT-D0-vqc"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rfe-gF-Wx9">
-                                                    <rect key="frame" x="60" y="35" width="108" height="28"/>
+                                                    <rect key="frame" x="60" y="35" width="108" height="28.5"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="20"/>
                                                     <color key="textColor" name="BoldUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eUM-71-kHR">
-                                                    <rect key="frame" x="178" y="36.5" width="116" height="30"/>
+                                                    <rect key="frame" x="178" y="37" width="116" height="30"/>
                                                     <state key="normal" title="Change Location"/>
                                                     <connections>
                                                         <action selector="changeLocationTapped:" destination="qaR-jP-1W0" eventType="touchUpInside" id="7T7-A2-aug"/>
@@ -801,7 +801,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connect using TCP only" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Axm-hd-YwD">
-                                                    <rect key="frame" x="16" y="12.5" width="225" height="19"/>
+                                                    <rect key="frame" x="16" y="11" width="225" height="22"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -834,7 +834,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Notify before session expiry" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HSr-1W-y5a">
-                                                    <rect key="frame" x="16" y="12.5" width="225" height="19"/>
+                                                    <rect key="frame" x="16" y="11" width="225" height="22"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -863,7 +863,7 @@
                                         <rect key="frame" x="0.0" y="303" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ybG-3O-5od" id="84I-6v-Tn8">
-                                            <rect key="frame" x="0.0" y="0.0" width="294.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="295.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Connection Log" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzv-dJ-o0C">
@@ -906,21 +906,45 @@
                             <tableViewSection headerTitle="About" footerTitle="For license information, please see the source code." id="zZ8-eL-KFl">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="clE-jt-jh6" detailTextLabel="6Vz-Gx-mbB" style="IBUITableViewCellStyleValue1" id="2bw-6y-6xS">
-                                        <rect key="frame" x="0.0" y="497.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="497.5" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2bw-6y-6xS" id="gCV-zU-1zY">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="clE-jt-jh6">
-                                                    <rect key="frame" x="16" y="13" width="74" height="19"/>
+                                                    <rect key="frame" x="16" y="11" width="76.5" height="22"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Version number" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6Vz-Gx-mbB">
-                                                    <rect key="frame" x="192" y="13" width="112" height="19"/>
+                                                    <rect key="frame" x="183.5" y="11" width="120.5" height="22"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
+                                                    <color key="textColor" name="RegularUITextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="lhK-GT-8mG" detailTextLabel="0Hi-Nu-JAJ" style="IBUITableViewCellStyleValue1" id="bHH-vX-fVh">
+                                        <rect key="frame" x="0.0" y="541" width="320" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bHH-vX-fVh" id="qth-Dq-9pR">
+                                            <rect key="frame" x="0.0" y="0.0" width="295.5" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Privacy statement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="lhK-GT-8mG">
+                                                    <rect key="frame" x="16" y="11" width="133.5" height="22"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
+                                                    <color key="textColor" name="RegularUITextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="0Hi-Nu-JAJ">
+                                                    <rect key="frame" x="244" y="11" width="43.5" height="22"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
@@ -930,21 +954,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Zsk-gl-9Hv" detailTextLabel="AyI-A2-tvn" style="IBUITableViewCellStyleValue1" id="4tU-D4-oc1">
-                                        <rect key="frame" x="0.0" y="541.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="584.5" width="320" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4tU-D4-oc1" id="8ys-ct-SxW">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Source code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zsk-gl-9Hv">
-                                                    <rect key="frame" x="16" y="13" width="91" height="19"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Source code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zsk-gl-9Hv">
+                                                    <rect key="frame" x="16" y="11" width="92" height="22"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" name="RegularUITextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="https://github.com/eduvpn/apple" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" id="AyI-A2-tvn">
-                                                    <rect key="frame" x="113" y="13" width="191" height="19"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="https://github.com/eduvpn/apple" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" id="AyI-A2-tvn">
+                                                    <rect key="frame" x="114" y="11" width="190" height="22"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                     <color key="textColor" systemColor="systemBlueColor"/>
@@ -970,7 +994,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6vD-7b-aVw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-884" y="2322"/>
+            <point key="canvasLocation" x="-1594" y="2321"/>
         </scene>
         <!--Log View Controller-->
         <scene sceneID="EOK-jM-elR">
@@ -1051,7 +1075,7 @@
                                         </connections>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JGc-id-Tai" userLabel="Add Server Button">
-                                        <rect key="frame" x="102" y="272" width="76" height="30"/>
+                                        <rect key="frame" x="101.5" y="272" width="77" height="30"/>
                                         <state key="normal" title="Add Server"/>
                                         <connections>
                                             <action selector="addServerTapped:" destination="QgS-AY-8Gr" eventType="touchUpInside" id="r8I-2C-ZbM"/>

--- a/EduVPN/Shims/NavigationController.swift
+++ b/EduVPN/Shims/NavigationController.swift
@@ -310,7 +310,7 @@ extension NavigationController {
         present(alert, animated: true, completion: nil)
     }
 
-    func showDisclaimer(onAccepted: @escaping () -> Void) {
+    func showDisclaimer(onAccepted: @escaping () -> Void, from fromVC: UIViewController? = nil) {
         let config = PrivacyStatementConfig.shared
         let title = config.title + "\n"
         let text = config.text
@@ -319,7 +319,7 @@ extension NavigationController {
                                          handler: { _ in onAccepted() })
         let alert = UIAlertController(title: title, message: text, preferredStyle: .actionSheet)
         alert.addAction(acceptAction)
-        present(alert, animated: true, completion: nil)
+        (fromVC ?? self).present(alert, animated: true, completion: nil)
     }
 }
 #endif


### PR DESCRIPTION
This PR adds access to the privacy statement from Settings (in the iOS app) / Preferences (in the macOS app).

Before this PR, once the user accepts the privacy statement, there's no way for her to read the statement again. This PR attempts to solve for that use case.