### PR TITLE
Ensure app works on the iPad

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Ensure app works on the iPad
+- Ensure Settings and Help buttons are visible on the iPad
+
 ## 3.0.0
 
 - Support for minisign pre-hashed signatures #427

--- a/EduVPN/Resources/iOS/Assets-eduVPN.xcassets/TopBarLogo.imageset/Contents.json
+++ b/EduVPN/Resources/iOS/Assets-eduVPN.xcassets/TopBarLogo.imageset/Contents.json
@@ -1,6 +1,7 @@
 {
   "images" : [
     {
+      "filename" : "eduVPN-Logo@1x.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
@@ -27,6 +28,7 @@
       "scale" : "1x"
     },
     {
+      "filename" : "eduVPN-Logo@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
@@ -53,6 +55,7 @@
       "scale" : "2x"
     },
     {
+      "filename" : "eduVPN-Logo@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     },

--- a/EduVPN/Resources/iOS/Common.xcassets/QuestionButton.imageset/Contents.json
+++ b/EduVPN/Resources/iOS/Common.xcassets/QuestionButton.imageset/Contents.json
@@ -1,6 +1,7 @@
 {
   "images" : [
     {
+      "filename" : "question@1x.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
@@ -27,6 +28,7 @@
       "scale" : "1x"
     },
     {
+      "filename" : "question@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
@@ -53,6 +55,7 @@
       "scale" : "2x"
     },
     {
+      "filename" : "question@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     },

--- a/EduVPN/Resources/iOS/Common.xcassets/SectionHeaderInstituteAccess.imageset/Contents.json
+++ b/EduVPN/Resources/iOS/Common.xcassets/SectionHeaderInstituteAccess.imageset/Contents.json
@@ -1,6 +1,7 @@
 {
   "images" : [
     {
+      "filename" : "institute_icon@1x.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
@@ -27,6 +28,7 @@
       "scale" : "1x"
     },
     {
+      "filename" : "institute_icon@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
@@ -53,6 +55,7 @@
       "scale" : "2x"
     },
     {
+      "filename" : "institute_icon@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     },

--- a/EduVPN/Resources/iOS/Common.xcassets/SectionHeaderOwnServer.imageset/Contents.json
+++ b/EduVPN/Resources/iOS/Common.xcassets/SectionHeaderOwnServer.imageset/Contents.json
@@ -1,6 +1,7 @@
 {
   "images" : [
     {
+      "filename" : "server_icon@1x.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
@@ -27,6 +28,7 @@
       "scale" : "1x"
     },
     {
+      "filename" : "server_icon@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
@@ -53,6 +55,7 @@
       "scale" : "2x"
     },
     {
+      "filename" : "server_icon@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     },

--- a/EduVPN/Resources/iOS/Common.xcassets/SectionHeaderSecureInternet.imageset/Contents.json
+++ b/EduVPN/Resources/iOS/Common.xcassets/SectionHeaderSecureInternet.imageset/Contents.json
@@ -1,6 +1,7 @@
 {
   "images" : [
     {
+      "filename" : "earth_icon@1x.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
@@ -27,6 +28,7 @@
       "scale" : "1x"
     },
     {
+      "filename" : "earth_icon@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
@@ -53,6 +55,7 @@
       "scale" : "2x"
     },
     {
+      "filename" : "earth_icon@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     },

--- a/EduVPN/Resources/iOS/Common.xcassets/SettingsButton.imageset/Contents.json
+++ b/EduVPN/Resources/iOS/Common.xcassets/SettingsButton.imageset/Contents.json
@@ -1,6 +1,7 @@
 {
   "images" : [
     {
+      "filename" : "settings@1x.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
@@ -27,6 +28,7 @@
       "scale" : "1x"
     },
     {
+      "filename" : "settings@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
@@ -53,6 +55,7 @@
       "scale" : "2x"
     },
     {
+      "filename" : "settings@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     },

--- a/EduVPN/Shims/NavigationController.swift
+++ b/EduVPN/Shims/NavigationController.swift
@@ -317,7 +317,7 @@ extension NavigationController {
         let acceptAction = UIAlertAction(title: NSLocalizedString("Accept", comment: "disclaimer button title"),
                                          style: .default,
                                          handler: { _ in onAccepted() })
-        let alert = UIAlertController(title: title, message: text, preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: title, message: text, preferredStyle: .alert)
         alert.addAction(acceptAction)
         (fromVC ?? self).present(alert, animated: true, completion: nil)
     }


### PR DESCRIPTION
This PR fixes issues found on the iPad:

- Fixes crash when showing the Privacy Statement (uses alert style now)
- Makes Settings and Help buttons visible
- Makes section header images in the main view visible
