### PR TITLE
Fix connected time being incorrect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Make connected time consistent with transferred data count #319
+
 ## 3.0.1
 
 - Fix when 'Renew Session' button is shown #460

--- a/EduVPN/Controllers/Mac/StatusItemConnectionInfoHelper.swift
+++ b/EduVPN/Controllers/Mac/StatusItemConnectionInfoHelper.swift
@@ -10,11 +10,7 @@ class StatusItemConnectionInfoHelper {
     private let connectionService: ConnectionServiceProtocol
     private let handler: (String) -> Void
 
-    private var transferredByteCount: TransferredByteCount? {
-        didSet {
-            self.update()
-        }
-    }
+    private var transferredByteCount: TransferredByteCount?
 
     private var timer: Timer? {
         didSet(oldValue) {
@@ -36,6 +32,7 @@ class StatusItemConnectionInfoHelper {
             self.connectionService.getTransferredByteCount()
         }.done { transferredByteCount in
             self.transferredByteCount = transferredByteCount
+            self.update()
         }
 
         let timer = Timer(timeInterval: 1 /*second*/, repeats: true) { [weak self] _ in
@@ -48,6 +45,7 @@ class StatusItemConnectionInfoHelper {
                 self.connectionService.getTransferredByteCount()
             }.done { transferredByteCount in
                 self.transferredByteCount = transferredByteCount
+                self.update()
             }
         }
         RunLoop.main.add(timer, forMode: .common)

--- a/EduVPN/Controllers/Mac/StatusItemConnectionInfoHelper.swift
+++ b/EduVPN/Controllers/Mac/StatusItemConnectionInfoHelper.swift
@@ -10,6 +10,7 @@ class StatusItemConnectionInfoHelper {
     private let connectionService: ConnectionServiceProtocol
     private let handler: (String) -> Void
 
+    private var connectedDate: Date?
     private var transferredByteCount: TransferredByteCount?
 
     private var timer: Timer? {
@@ -29,8 +30,12 @@ class StatusItemConnectionInfoHelper {
 
     func startUpdating() {
         firstly {
+            self.connectionService.getConnectedDate()
+        }.then { connectedDate in
             self.connectionService.getTransferredByteCount()
-        }.done { transferredByteCount in
+                .map { (connectedDate, $0) }
+        }.done { connectedDate, transferredByteCount in
+            self.connectedDate = connectedDate
             self.transferredByteCount = transferredByteCount
             self.update()
         }
@@ -42,8 +47,12 @@ class StatusItemConnectionInfoHelper {
                 return
             }
             firstly {
+                self.connectionService.getConnectedDate()
+            }.then { connectedDate in
                 self.connectionService.getTransferredByteCount()
-            }.done { transferredByteCount in
+                    .map { (connectedDate, $0) }
+            }.done { connectedDate, transferredByteCount in
+                self.connectedDate = connectedDate
                 self.transferredByteCount = transferredByteCount
                 self.update()
             }
@@ -68,7 +77,7 @@ private extension StatusItemConnectionInfoHelper {
     }()
 
     private var connectedDuration: String? {
-        guard let connectedDate = connectionService.connectedDate else { return nil }
+        guard let connectedDate = self.connectedDate else { return nil }
         return Self.durationFormatter.string(from: connectedDate, to: Date())
     }
 

--- a/EduVPN/Services/MockConnectionService.swift
+++ b/EduVPN/Services/MockConnectionService.swift
@@ -93,6 +93,13 @@ class MockConnectionService: ConnectionServiceProtocol {
         return .value(TransferredByteCount(inbound: 0, outbound: 0))
     }
 
+    func getConnectedDate() -> Guarantee<Date?> {
+        guard isInitialized else {
+            fatalError("ConnectionService not initialized yet")
+        }
+        return .value(connectedDate)
+    }
+
     func getConnectionLog() -> Promise<String?> {
         guard isInitialized else {
             fatalError("ConnectionService not initialized yet")

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -728,7 +728,7 @@ extension ConnectionViewModel: ConnectionServiceStatusDelegate {
     func connectionService(_ service: ConnectionServiceProtocol, connectionStatusChanged status: NEVPNStatus) {
         connectionStatus = status
         if status == .connected {
-            connectionInfoHelper?.refreshNetworkAddress()
+            connectionInfoHelper?.refreshAfterConnectOrReconnect()
         }
         if status == .disconnected {
             connectionInfoHelper = nil

--- a/Shared/Shared.swift
+++ b/Shared/Shared.swift
@@ -12,8 +12,22 @@ enum TunnelMessageCode: UInt8 {
     case getTransferredByteCount = 0 // Returns TransferredByteCount as Data
     case getNetworkAddresses = 1 // Returns [String] as JSON
     case getLog = 2 // Returns UTF-8 string
+    case getConnectedDate = 3 // Returns UInt64 as Data
 
     var data: Data { Data([rawValue]) }
+}
+
+extension Date {
+    func toData() -> Data {
+        var secondsSince1970 = UInt64(self.timeIntervalSince1970)
+        let data: Data = withUnsafeBytes(of: &secondsSince1970) { Data($0) }
+        return data
+    }
+
+    init(fromData data: Data) {
+        let secondsSince1970: UInt64 = data.withUnsafeBytes { $0.load(as: UInt64.self) }
+        self = Date(timeIntervalSince1970: TimeInterval(secondsSince1970))
+    }
 }
 
 struct TransferredByteCount: Codable {

--- a/WireGuardTunnelExtension/PacketTunnelProvider.swift
+++ b/WireGuardTunnelExtension/PacketTunnelProvider.swift
@@ -15,6 +15,8 @@ enum PacketTunnelProviderError: Error {
 
 class PacketTunnelProvider: NEPacketTunnelProvider {
 
+    var connectedDate: Date?
+
     // Logging
     var logger: Logger?
     var tunnelConfiguration: TunnelConfiguration?
@@ -59,6 +61,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 let interfaceName = self.adapter.interfaceName ?? "unknown"
                 logger.log("Tunnel interface is \(interfaceName)")
             }
+            self.connectedDate = Date()
             completionHandler(adapterError)
         }
     }
@@ -114,6 +117,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 data.append("\n".data(using: .utf8) ?? Data())
             }
             completionHandler?(data)
+        case .getConnectedDate:
+            completionHandler?(connectedDate?.toData())
         }
     }
 }


### PR DESCRIPTION
Resolves #319

Previously, we got the connected date in the app by looking at `NEVPNConnection.connectedDate`. That value didn't get updated across sleep-wakeups (when the OpenVPN tunnel might get disconnected / reconnected which would reset the data counters). So in this PR, we get the connected date by querying the tunnel extension.