### PR TITLE
eduVPN bugfixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Make connected time consistent with transferred data count #319
+- When deleting a single secure internet server, app
+  should automatically show the search screen
 
 ## 3.0.1
 

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -412,19 +412,21 @@ extension MainViewController: MainViewModelDelegate {
             isTableViewInitialized = true
             return
         }
-        reloadSecureInternetAvailableServers()
-        if changes.deletedIndices.isEmpty && changes.insertions.isEmpty {
-            return
+        if !changes.deletedIndices.isEmpty || !changes.insertions.isEmpty {
+            delegate?.mainViewControllerAddedServersListChanged(self)
         }
-        delegate?.mainViewControllerAddedServersListChanged(self)
         #if os(iOS)
         guard isViewVisible else {
             hasPendingUpdates = true
             return
         }
         #endif
+        // Always assume secureInternetHeaderRow is updated because the
+        // country list might have changed.
+        let updatedIndices = [self.viewModel.secureInternetHeaderRowIndex()].compactMap { $0 }
         tableView.performUpdates(deletedIndices: changes.deletedIndices,
-                                 insertedIndices: changes.insertions.map { $0.0 })
+                                 insertedIndices: changes.insertions.map { $0.0 },
+                                 updatedIndices: updatedIndices)
     }
 }
 
@@ -433,12 +435,5 @@ extension MainViewController {
         guard let tableView = tableView else { return }
         let indices = self.viewModel.secureInternetRowIndices()
         tableView.reloadRows(indices: indices)
-    }
-
-    func reloadSecureInternetAvailableServers() {
-        guard let tableView = tableView else { return }
-        if let index = self.viewModel.secureInternetHeaderRowIndex() {
-            tableView.reloadRows(indices: [index])
-        }
     }
 }

--- a/EduVPN/Controllers/SearchViewController.swift
+++ b/EduVPN/Controllers/SearchViewController.swift
@@ -252,7 +252,8 @@ extension SearchViewController: SearchViewModelDelegate {
         _ model: SearchViewModel,
         rowsChanged changes: RowsDifference<SearchViewModel.Row>) {
         tableView?.performUpdates(deletedIndices: changes.deletedIndices,
-                                  insertedIndices: changes.insertions.map { $0.0 })
+                                  insertedIndices: changes.insertions.map { $0.0 },
+                                  updatedIndices: [])
     }
 }
 

--- a/EduVPN/Services/PersistenceService.swift
+++ b/EduVPN/Services/PersistenceService.swift
@@ -132,6 +132,7 @@ class PersistenceService {
         }
         addedServers.secureInternetServer = nil
         Self.saveToFile(addedServers: addedServers)
+        updateHasServers()
     }
 
     func addOpenVPNConfiguration(_ instance: OpenVPNConfigInstance) {

--- a/EduVPN/Shims/Multiplatform.swift
+++ b/EduVPN/Shims/Multiplatform.swift
@@ -76,11 +76,12 @@ extension TableView {
         return dequeueReusableCell(withIdentifier: identifier, for: indexPath) as! T
     }
 
-    func performUpdates(deletedIndices: [Int], insertedIndices: [Int]) {
+    func performUpdates(deletedIndices: [Int], insertedIndices: [Int], updatedIndices: [Int]) {
         UIView.setAnimationsEnabled(false)
         beginUpdates()
         deleteRows(at: deletedIndices.map { IndexPath(row: $0, section: 0) }, with: .none)
         insertRows(at: insertedIndices.map { IndexPath(row: $0, section: 0) }, with: .none)
+        reloadRows(at: updatedIndices.map { IndexPath(row: $0, section: 0) }, with: .none)
         endUpdates()
         UIView.setAnimationsEnabled(true)
     }
@@ -192,11 +193,16 @@ extension TableView {
         return cellView as! T // swiftlint:disable:this force_cast
     }
 
-    func performUpdates(deletedIndices: [Int], insertedIndices: [Int]) {
-        beginUpdates()
-        removeRows(at: IndexSet(deletedIndices), withAnimation: [])
-        insertRows(at: IndexSet(insertedIndices), withAnimation: [])
-        endUpdates()
+    func performUpdates(deletedIndices: [Int], insertedIndices: [Int], updatedIndices: [Int]) {
+        if !deletedIndices.isEmpty || !insertedIndices.isEmpty {
+            beginUpdates()
+            removeRows(at: IndexSet(deletedIndices), withAnimation: [])
+            insertRows(at: IndexSet(insertedIndices), withAnimation: [])
+            endUpdates()
+        }
+        if !updatedIndices.isEmpty {
+            reloadData(forRowIndexes: IndexSet(updatedIndices), columnIndexes: IndexSet([0]))
+        }
     }
 
     func reloadRows(indices: [Int]) {


### PR DESCRIPTION
This PR fixes a couple of bugs in master that would show up only in the eduVPN app

1. When adding / removing a server when a secure internet server exists, the app crashes because of the way UITableView handles reloads. (iOS only)
2. When the last server deleted is a secure internet server, the app doesn't automatically go back to the search screen. (iOS and macOS)
