### PR TITLE
Postpone renew session until the app is in the foreground

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Make connected time consistent with transferred data count #319
+- Attempt to fix ASWebAuthenticationSession failure when clicking
+  on a session expiry notification #469
 
 ## 3.0.1
 


### PR DESCRIPTION
Attempts to fix #469 

I can't reproduce the reported problem, but the reported problem looks very similar to https://github.com/openid/AppAuth-iOS/issues/498, so I think this PR should fix it. We can merge this and have @efef check if the issue is solved or not.