### PR TITLE
TunnelKit: Queue the data packets to avoid crypto errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Bring back ENOBUFS fix
+- Avoid crypto errors (103) while sending packets #481
+
 ## 3.0.3
 
 - Move project to use Swift Package Manager instead of Cocoapods #95

--- a/LocalPackages/tunnelkit/Sources/TunnelKitAppExtension/Transport/NETunnelInterface.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitAppExtension/Transport/NETunnelInterface.swift
@@ -57,17 +57,16 @@ public class NETunnelInterface: TunnelInterface {
     
     // MARK: IOInterface
     
-    public func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void) {
+    public func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?, @escaping () -> Void) -> Void) {
         loopReadPackets(queue, handler)
     }
     
-    private func loopReadPackets(_ queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void) {
+    private func loopReadPackets(_ queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?, @escaping () -> Void) -> Void) {
 
         // WARNING: runs in NEPacketTunnelFlow queue
         impl?.readPackets { [weak self] (packets, protocols) in
-            queue.sync {
+            handler(packets, nil) {
                 self?.loopReadPackets(queue, handler)
-                handler(packets, nil)
             }
         }
     }

--- a/LocalPackages/tunnelkit/Sources/TunnelKitCore/TunnelInterface.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitCore/TunnelInterface.swift
@@ -47,8 +47,9 @@ public protocol TunnelInterface {
 
      - Parameter queue: The queue where to invoke the handler on.
      - Parameter handler: The handler invoked whenever an array of `Data` packets is received, with an optional `Error` in case a network failure occurs.
+                          The handler also receives a closure that the handler should call on successful completion of handling the read.
      */
-    func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void)
+    func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?, @escaping () -> Void) -> Void)
 
     /**
      Writes a packet to the interface.

--- a/LocalPackages/tunnelkit/Sources/TunnelKitCore/TunnelInterface.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitCore/TunnelInterface.swift
@@ -37,8 +37,32 @@
 import Foundation
 
 /// Represents a specific I/O interface meant to work at the tunnel layer (e.g. VPN).
-public protocol TunnelInterface: IOInterface {
+public protocol TunnelInterface {
 
     /// When `true`, interface survives sessions.
     var isPersistent: Bool { get }
+
+    /**
+     Sets the handler for incoming packets. This only needs to be set once.
+
+     - Parameter queue: The queue where to invoke the handler on.
+     - Parameter handler: The handler invoked whenever an array of `Data` packets is received, with an optional `Error` in case a network failure occurs.
+     */
+    func setReadHandler(queue: DispatchQueue, _ handler: @escaping ([Data]?, Error?) -> Void)
+
+    /**
+     Writes a packet to the interface.
+
+     - Parameter packet: The `Data` packet to write.
+     - Parameter completionHandler: Invoked on write completion, with an optional `Error` in case a network failure occurs.
+     */
+    func writePacket(_ packet: Data, completionHandler: ((Error?) -> Void)?)
+
+    /**
+     Writes some packets to the interface.
+
+     - Parameter packets: The array of `Data` packets to write.
+     - Parameter completionHandler: Invoked on write completion, with an optional `Error` in case a network failure occurs.
+     */
+    func writePackets(_ packets: [Data], completionHandler: ((Error?) -> Void)?)
 }

--- a/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNProtocol/OpenVPNSession.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNProtocol/OpenVPNSession.swift
@@ -160,7 +160,9 @@ public class OpenVPNSession: Session {
     private var lastPing: BidirectionalState<Date>
     
     private(set) var isStopping: Bool
-    
+
+    private var isWaitingForSendBufferSpace: Bool
+
     /// The optional reason why the session stopped.
     public private(set) var stopError: Error?
     
@@ -202,7 +204,8 @@ public class OpenVPNSession: Session {
         isRenegotiating = false
         lastPing = BidirectionalState(withResetValue: Date.distantPast)
         isStopping = false
-        
+        isWaitingForSendBufferSpace = false
+
         if let tlsWrap = configuration.tlsWrap {
             switch tlsWrap.strategy {
             case .auth:
@@ -391,8 +394,14 @@ public class OpenVPNSession: Session {
                 return
             }
             if let error = error {
-                log.error("Failed LINK read: \(error)")
-                
+
+                if self?.isWaitingForSendBufferSpace ?? false,
+                   let posixError = error as? POSIXError, posixError.code == POSIXErrorCode.ENOBUFS {
+                    // Suppress logging this error
+                } else {
+                    log.error("Failed LINK read: \(error)")
+                }
+
                 // XXX: why isn't the tunnel shutting down at this point?
                 return
             }
@@ -1196,7 +1205,9 @@ public class OpenVPNSession: Session {
                 if let error = error {
                     if let posixError = error as? POSIXError, posixError.code == POSIXErrorCode.ENOBUFS {
                         log.debug("Data: Encountered ENOBUFS while sending. Will retry after 1 second.")
+                        self.isWaitingForSendBufferSpace = true
                         self.queue.asyncAfter(deadline: .now() + .milliseconds(1000)) {
+                            self.isWaitingForSendBufferSpace = false
                             self.sendDataPackets(packets, onSuccess: onSuccess)
                         }
                     } else {

--- a/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNProtocol/OpenVPNSession.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNProtocol/OpenVPNSession.swift
@@ -408,7 +408,7 @@ public class OpenVPNSession: Session {
 
     // Ruby: tun_loop
     private func loopTunnel() {
-        tunnel?.setReadHandler(queue: queue) { [weak self] (newPackets, error) in
+        tunnel?.setReadHandler(queue: queue) { [weak self] (newPackets, error, onSuccess) in
             if let error = error {
                 log.error("Failed TUN read: \(error)")
                 return
@@ -416,7 +416,7 @@ public class OpenVPNSession: Session {
 
             if let packets = newPackets, !packets.isEmpty {
 //                log.verbose("Received \(packets.count) packets from TUN")
-                self?.receiveTunnel(packets: packets)
+                self?.receiveTunnel(packets: packets, onSuccess: onSuccess)
             }
         }
     }
@@ -523,12 +523,12 @@ public class OpenVPNSession: Session {
     }
     
     // Ruby: recv_tun
-    private func receiveTunnel(packets: [Data]) {
+    private func receiveTunnel(packets: [Data], onSuccess: @escaping () -> Void) {
         guard shouldHandlePackets() else {
             log.warning("Discarding \(packets.count) TUN packets (should not handle)")
             return
         }
-        sendDataPackets(packets)
+        sendDataPackets(packets, onSuccess: onSuccess)
     }
     
     // Ruby: ping
@@ -547,7 +547,7 @@ public class OpenVPNSession: Session {
         // is keep-alive enabled?
         if let _ = keepAliveInterval {
             log.debug("Send ping")
-            sendDataPackets([OpenVPN.DataPacket.pingString])
+            sendDataPackets([OpenVPN.DataPacket.pingString], onSuccess: {})
             lastPing.outbound = Date()
         }
 
@@ -1169,7 +1169,7 @@ public class OpenVPNSession: Session {
     }
     
     // Ruby: send_data_pkt
-    private func sendDataPackets(_ packets: [Data]) {
+    private func sendDataPackets(_ packets: [Data], onSuccess: @escaping () -> Void) {
         guard let key = currentKey else {
             return
         }
@@ -1186,19 +1186,18 @@ public class OpenVPNSession: Session {
             controlChannel.addSentDataCount(encryptedPackets.flatCount)
             let writeLink = link
             link?.writePackets(encryptedPackets) { [weak self] (error) in
-                self?.queue.sync {
-                    guard self?.link === writeLink else {
-                        log.warning("Ignoring write from outdated LINK")
-                        return
-                    }
-                    if let error = error {
-                        log.error("Data: Failed LINK write during send data: \(error)")
-                        log.debug("Initiating shutdown")
-                        self?.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
-                        return
-                    }
-//                    log.verbose("Data: \(encryptedPackets.count) packets successfully written to LINK")
+                guard self?.link === writeLink else {
+                    log.warning("Ignoring write from outdated LINK")
+                    return
                 }
+                if let error = error {
+                    log.error("Data: Failed LINK write during send data: \(error)")
+                    log.debug("Initiating shutdown")
+                    self?.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
+                    return
+                }
+                onSuccess()
+//              log.verbose("Data: \(encryptedPackets.count) packets successfully written to LINK")
             }
         } catch let e {
             guard !e.isOpenVPNError() else {

--- a/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNProtocol/OpenVPNSession.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNProtocol/OpenVPNSession.swift
@@ -1186,17 +1186,28 @@ public class OpenVPNSession: Session {
             controlChannel.addSentDataCount(encryptedPackets.flatCount)
             let writeLink = link
             link?.writePackets(encryptedPackets) { [weak self] (error) in
-                guard self?.link === writeLink else {
+                guard let self = self else {
+                    return
+                }
+                guard self.link === writeLink else {
                     log.warning("Ignoring write from outdated LINK")
                     return
                 }
                 if let error = error {
-                    log.error("Data: Failed LINK write during send data: \(error)")
-                    log.debug("Initiating shutdown")
-                    self?.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
-                    return
+                    if let posixError = error as? POSIXError, posixError.code == POSIXErrorCode.ENOBUFS {
+                        log.debug("Data: Encountered ENOBUFS while sending. Will retry after 1 second.")
+                        self.queue.asyncAfter(deadline: .now() + .milliseconds(1000)) {
+                            self.sendDataPackets(packets, onSuccess: onSuccess)
+                        }
+                    } else {
+                        log.error("Data: Failed LINK write during send data: \(error)")
+                        log.debug("Initiating shutdown")
+                        self.deferStop(.shutdown, OpenVPNError.failedLinkWrite)
+                    }
+                } else {
+                    // Trigger getting of more to-be-sent-out packets from the TUN interface
+                    onSuccess()
                 }
-                onSuccess()
 //              log.verbose("Data: \(encryptedPackets.count) packets successfully written to LINK")
             }
         } catch let e {


### PR DESCRIPTION
Fixes #481.

When sending data packets, the encryption currently happens in the NEPacketTunnelFlow's queue. The OpenVPN ping packets are sent from the OpenVPNSession object's queue. This results in encryptions happening in parallel, especially when sending lots of packets in a short time. Since both kinds of packets use the same crypto context, this results in the same crypto context being accessed from two different threads at the same time.

Consider the code for [encryptBytes](https://github.com/eduvpn/apple/blob/master/LocalPackages/tunnelkit/Sources/CTunnelKitOpenVPNProtocol/CryptoAEAD.m#L123). If two threads are simultaneously executing that method, and both thread have finished EVP_CipherInit, then after one thread exits EVP_CipherFinal_ex, the other thread's EVP_CipherFinal_ex call [fails](https://github.com/openssl/openssl/blob/fb047ebc87b18bdc4cf9ddee9ee1f5ed93e56aff/crypto/evp/e_aes.c#L3195) because [the same IV can't be reused](https://github.com/openssl/openssl/blob/fb047ebc87b18bdc4cf9ddee9ee1f5ed93e56aff/crypto/evp/e_aes.c#L3302). (EVP_CipherFinal_ex() calls aes_gcm_cipher() [here](https://github.com/openssl/openssl/blob/fb047ebc87b18bdc4cf9ddee9ee1f5ed93e56aff/crypto/evp/evp_enc.c#L428) when using AES-256-GCM cipher). The OpenSSL API is not designed to be used from different threads on the same context.

So the fix is to make the data packets' encryption also happen in the OpenVPNSession object's queue.