### PR TITLE
Fix no-internet issues in OpenVPN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Bring back ENOBUFS fix
 - Avoid crypto errors (103) while sending packets #481
+- Fix no-internet issues #485
 
 ## 3.0.3
 

--- a/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
@@ -489,7 +489,8 @@ extension OpenVPNTunnelProvider: GenericSocketDelegate {
         // fallback: UDP is connection-less, treat negotiation timeout as socket timeout
         if didTimeoutNegotiation {
             guard tryNextEndpoint() else {
-                // disposeTunnel
+                // If there are no more endpoints, cancel the tunnel
+                disposeTunnel(error: shutdownError)
                 return
             }
         }

--- a/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
+++ b/LocalPackages/tunnelkit/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
@@ -503,6 +503,7 @@ extension OpenVPNTunnelProvider: GenericSocketDelegate {
                 // give up if shouldReconnect cleared in the meantime
                 guard self.shouldReconnect else {
                     log.warning("Reconnection flag was cleared in the meantime")
+                    self.disposeTunnel(error: shutdownError)
                     return
                 }
 


### PR DESCRIPTION
Fixes #485.

When the tunnel is not in a position to work anymore, cancel the tunnel (i.e. tell the OS to dismantle the tunnel). Then the tunnel process shall exit and the on-demand shall make the OS launch the tunnel afresh when required. If we don't do this, the tunnel sometimes gets to a state where the tunnel process is alive but is not handing any packets.