### PR TITLE
iOS: Fix UI updating when deleting a server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- iOS: Fix crash when deleting servers #503
+
 ## 3.0.6
 
 - iOS: Add 'Copy Log' button in log view

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -102,6 +102,7 @@ class MainViewController: ViewController {
             queue: OperationQueue.main) { [weak self] _ in
                 self?.isAppInForeground = false
         }
+        isViewVisible = true
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
It looks like viewDidAppear never gets called when we launch into the main VC, so we should look for the viewDidLoad call as well.

Probably fixes #503.
