### PR TITLE
Fix showing About panel from status item menu

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - iOS: Fix crash when deleting servers #503
+- macOS: Fix showing About panel from status item menu #497
 
 ## 3.0.6
 

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -259,6 +259,7 @@ extension AppDelegate {
     }
 
     @IBAction func showAboutPanel(_ sender: Any?) {
+        NSApp.activate(ignoringOtherApps: true)
         NSApp.orderFrontStandardAboutPanel(options: [
             .credits: sourceRepositoryLinkMessage
         ])

--- a/EduVPN/Controllers/Mac/StatusItemController.swift
+++ b/EduVPN/Controllers/Mac/StatusItemController.swift
@@ -360,7 +360,7 @@ private extension StatusItemController {
     }
 
     @objc func aboutMenuItemClicked() {
-        NSApp.orderFrontStandardAboutPanel(self)
+        (NSApp.delegate as? AppDelegate)?.showAboutPanel(self)
     }
 
     @objc func quitMenuItemClicked() {


### PR DESCRIPTION
Fixes #497.

We need to activate the app when showing the About panel.
