### PR TITLE
Suppress sleep wake handling in ios

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - iOS: Fix crash when deleting servers #503
 - macOS: Fix showing About panel from status item menu #497
+- iOS: Prevent disconnect / connect cycles when device is locked #493
 
 ## 3.0.6
 

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -3270,7 +3270,7 @@
 			repositoryURL = "https://github.com/eduvpn/tunnelkit.git";
 			requirement = {
 				kind = revision;
-				revision = ddb080576489835ea1061e6679d30e1a20f9cf6f;
+				revision = 14d0610003f54f2c107875a17d8c1ba917b1465a;
 			};
 		};
 		6FEF3F1E28ADD638005E65CB /* XCRemoteSwiftPackageReference "AppAuth-iOS" */ = {

--- a/EduVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EduVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -90,7 +90,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eduvpn/tunnelkit.git",
       "state" : {
-        "revision" : "ddb080576489835ea1061e6679d30e1a20f9cf6f"
+        "revision" : "14d0610003f54f2c107875a17d8c1ba917b1465a"
       }
     },
     {

--- a/OpenVPNTunnelExtension/PacketTunnelProvider.swift
+++ b/OpenVPNTunnelExtension/PacketTunnelProvider.swift
@@ -23,7 +23,7 @@ enum PacketTunnelProviderError: Error {
 
 class PacketTunnelProvider: NEPacketTunnelProvider {
 
-    private lazy var adapter = OpenVPNAdapter(with: self)
+    private lazy var adapter = OpenVPNAdapter(with: self, flushLogHandler: { self.logger?.flushToDisk() })
 
     var connectedDate: Date?
     var logger: Logger?
@@ -122,11 +122,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func wake() {
-        adapter.wake()
+        adapter.resume()
     }
 
     override func sleep(completionHandler: @escaping () -> Void) {
-        adapter.sleep(completionHandler: completionHandler)
+        adapter.pause(completionHandler: completionHandler)
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {

--- a/OpenVPNTunnelExtension/PacketTunnelProvider.swift
+++ b/OpenVPNTunnelExtension/PacketTunnelProvider.swift
@@ -122,11 +122,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func wake() {
+#if os(iOS)
+        // Nothing to do
+#else
         adapter.resume()
+#endif
     }
 
     override func sleep(completionHandler: @escaping () -> Void) {
+#if os(iOS)
+        // Nothing to do
+        completionHandler()
+#else
         adapter.pause(completionHandler: completionHandler)
+#endif
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {


### PR DESCRIPTION
Fixes #493.

iOS seems to keep sending the tunnel sleep / wake notifications while the device is locked (could be for background network access). So in this PR, we don't do anything on these notifications for iOS (and continue to pause / resume the tunnel in macOS), and just let the OS manage the tunnel as it sees fit (because on-demand is still on).
