### PR TITLE
Suppress retry on auth failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - iOS: Fix crash when deleting servers #503
 - macOS: Fix showing About panel from status item menu #497
 - iOS: Prevent disconnect / connect cycles when device is locked #493
+- Avoid endless retry after authentication is revoked #494
 
 ## 3.0.6
 

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -3270,7 +3270,7 @@
 			repositoryURL = "https://github.com/eduvpn/tunnelkit.git";
 			requirement = {
 				kind = revision;
-				revision = 14d0610003f54f2c107875a17d8c1ba917b1465a;
+				revision = 2b0032ecfe67eaa2c9c3d7d400df28911418d6c8;
 			};
 		};
 		6FEF3F1E28ADD638005E65CB /* XCRemoteSwiftPackageReference "AppAuth-iOS" */ = {

--- a/EduVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EduVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -90,7 +90,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eduvpn/tunnelkit.git",
       "state" : {
-        "revision" : "14d0610003f54f2c107875a17d8c1ba917b1465a"
+        "revision" : "2b0032ecfe67eaa2c9c3d7d400df28911418d6c8"
       }
     },
     {

--- a/OpenVPNTunnelExtension/PacketTunnelProvider.swift
+++ b/OpenVPNTunnelExtension/PacketTunnelProvider.swift
@@ -109,6 +109,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
         adapter.appVersion = appVersionString
 
+        if !startTunnelOptions.isStartedByApp {
+            adapter.authFailShutdownHandler = { [weak self] in
+                // Using deprecated call because there's no alternative
+                self?.displayMessage(
+                    """
+                    VPN authentication failed. You can re-authenticate your VPN
+                    connection in the app by turning it off, and then back on.
+                    """,
+                    completionHandler: { _ in })
+            }
+        }
+
         adapter.start(providerConfiguration: providerConfig, credentials: credentials, completionHandler: completionHandler)
     }
 

--- a/OpenVPNTunnelExtension/PacketTunnelProvider.swift
+++ b/OpenVPNTunnelExtension/PacketTunnelProvider.swift
@@ -23,7 +23,7 @@ enum PacketTunnelProviderError: Error {
 
 class PacketTunnelProvider: NEPacketTunnelProvider {
 
-    private lazy var adapter = OpenVPNAdapter(with: self, flushLogHandler: { self.logger?.flushToDisk() })
+    private lazy var adapter = OpenVPNAdapter(with: self)
 
     var connectedDate: Date?
     var logger: Logger?
@@ -108,6 +108,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             appVersionString += " (\(appBuild))"
         }
         adapter.appVersion = appVersionString
+
+        adapter.flushLogHandler = { logger.flushToDisk() }
 
         if !startTunnelOptions.isStartedByApp {
             adapter.authFailShutdownHandler = { [weak self] in


### PR DESCRIPTION
Fixes #494.

When the tunnel is on, and the authorisation is revoked on the server, then the OpenVPN tunnel will error out and try to reconnect. Because of on-demand, the OS keeps trying to turn the tunnel on, and the client keeps contacting the server again and again.

To prevent this, in this PR, when the tunnel is turned on by the OS, if the tunnel sees an unrecoverable AUTH_FAIL, it shuts down the tunnel but keeps the tunnel process alive. It also tries to show a message to the user with a deprecated API (displayMessage()), which seems to work on macOS but not on iOS. To the user, the tunnel will be in "Connecting ..." state.
