### PR TITLE
Make block local work in IPv6 as well

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - macOS: Fix showing About panel from status item menu #497
 - iOS: Prevent disconnect / connect cycles when device is locked #493
 - Avoid endless retry after authentication is revoked #494
+- Make block-local work in IPv6 #323
 
 ## 3.0.6
 

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -3270,7 +3270,7 @@
 			repositoryURL = "https://github.com/eduvpn/tunnelkit.git";
 			requirement = {
 				kind = revision;
-				revision = 2b0032ecfe67eaa2c9c3d7d400df28911418d6c8;
+				revision = f429162f8914ee218fd6d5aa9733de1cdbea11e2;
 			};
 		};
 		6FEF3F1E28ADD638005E65CB /* XCRemoteSwiftPackageReference "AppAuth-iOS" */ = {


### PR DESCRIPTION
Fixes #323.

The actual code changes are in eduvpn/tunnelkit ([Commit](https://github.com/eduvpn/tunnelkit/commit/f429162f8914ee218fd6d5aa9733de1cdbea11e2)).

The original code used to do:
  - Find the default route
  - Find the broadest route routing into the gateway of the default route
  - Partition that route into two routes (to make that override the original route), routing into the tunnel

In IPv6, the following things make this not work:
  - Some default routes route into non-existant "utun" interfaces (maybe not cleaned up by the OS yet)
      - Solution: Need filter out these routes
  - The broadest route can be a link-local address
      - Solution: Need to find a link-layer address that routes into the interface of the default route (broadest, if there are many)

To test it:
  - Connect to a wifi network that allocates a public IPv6 address to our machine (say A)
  - In another machine (say B), connect to the same network
  - run ifconfig en0 in Machine B, note down the secured IPv6 address
  - From Machine A, ping6 to the Machine B's IPv6 address (should work)
  - Connect to a VPN
  - From Machine A, ping6 to the Machine B's IPv6 address (should not work while tunnel is on)
