### PR TITLE
Do not use AuthState with non-matching endpoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - macOS: Fix showing About panel from status item menu #497
 - iOS: Prevent disconnect / connect cycles when device is locked #493
 - Avoid endless retry after authentication is revoked #494
+- Avoid using cached token endpoints from OIDAuthState #487
 
 ## 3.0.6
 

--- a/EduVPN/Models/AuthState.swift
+++ b/EduVPN/Models/AuthState.swift
@@ -14,4 +14,10 @@ struct AuthState {
     init(oidAuthState: OIDAuthState) {
         self.oidAuthState = oidAuthState
     }
+
+    func hasSameEndpoints(as serverInfo: ServerInfo) -> Bool {
+        let oidServiceConfig = oidAuthState.lastAuthorizationResponse.request.configuration
+        return ((oidServiceConfig.authorizationEndpoint == serverInfo.authorizationEndpoint) &&
+                (oidServiceConfig.tokenEndpoint == serverInfo.tokenEndpoint))
+    }
 }

--- a/EduVPN/Services/ServerAPIService.swift
+++ b/EduVPN/Services/ServerAPIService.swift
@@ -175,6 +175,10 @@ extension ServerAPIHandler {
             guard let authState = commonInfo.dataStore.authState else {
                 throw ServerAPIServiceError.cannotUseStoredAuthState
             }
+            guard authState.hasSameEndpoints(as: commonInfo.serverInfo) else {
+                os_log("Not using auth state that contains cached incorrect endpoints")
+                throw ServerAPIServiceError.cannotUseStoredAuthState
+            }
             return self.getFreshAccessToken(using: authState, storingChangesTo: commonInfo.dataStore)
         }.recover { error -> Promise<String> in
             os_log("Error getting access token: %{public}@", log: Log.general, type: .error,


### PR DESCRIPTION
Fixes #487.

In moving from APIv2 to APIv3, the server endpoints changed. After that, when the client connects to the server, it resulted in an error because the client was using a cached OIDAuthState object, which included the endpoints used -- when refreshing the token, AppAuth used the endpoints stored in the OIDAuthState, instead of the provided endpoints.

In this PR, we check if the endpoints stored in the OIDAuthState are the same as the ones we want to contact. AppAuth exposes the endpoints stored in the AuthState, so we are able to check it without having to modify AppAuth.