### PR TITLE
macOS: Autoconnect on launch at login

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Avoid using cached token endpoints from OIDAuthState #487
 - macOS: Point the user to the OS' please-enable-notification prompt #474 
 - Improve error alerts #489
+- macOS: Autoconnect on launch at login if machine was shutdown with VPN on #478
 
 ## 3.0.6
 

--- a/EduVPN/AppDelegate.swift
+++ b/EduVPN/AppDelegate.swift
@@ -76,8 +76,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             shouldUseColorIcons: UserDefaults.standard.isStatusItemInColor)
         setShowInDockEnabled(UserDefaults.standard.showInDock)
 
-        if LaunchAtLoginHelper.isOpenedOrReopenedByLoginItemHelper() &&
-            UserDefaults.standard.showInStatusBar {
+        let isLauncedAtLogin = LaunchAtLoginHelper.isOpenedOrReopenedByLoginItemHelper()
+
+        if isLauncedAtLogin && UserDefaults.standard.shouldReconnectOnLaunchAtLogin {
+            mainViewController?.reconnectLastUsedConnectionWhenPossible()
+        }
+        UserDefaults.standard.shouldReconnectOnLaunchAtLogin = false
+
+        if isLauncedAtLogin && UserDefaults.standard.showInStatusBar {
             // If we're showing a status item and the app was launched because
             //  the user logged in, don't show the window
             window.close()
@@ -226,6 +232,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if isQuittingForLogoutShutdownOrRestart() {
+            UserDefaults.standard.shouldReconnectOnLaunchAtLogin = true
             return silentlyStopVPNAndQuit(connectionService: connectionService)
         } else {
             return showAlertConfirmingStopVPNAndQuit(connectionService: connectionService)

--- a/EduVPN/Controllers/Mac/MainViewController+StatusItem.swift
+++ b/EduVPN/Controllers/Mac/MainViewController+StatusItem.swift
@@ -36,8 +36,7 @@ extension MainViewController: StatusItemControllerDelegate {
         }.map {
             self.pushConnectionVC(
                 connectableInstance: connectableInstance,
-                preConnectionState: nil,
-                continuationPolicy: .continueWithAnyProfile)
+                postLoadAction: .beginConnectionFlow(continuationPolicy: .continueWithAnyProfile))
         }.cauterize()
     }
 }

--- a/EduVPN/Controllers/MainViewController.swift
+++ b/EduVPN/Controllers/MainViewController.swift
@@ -156,7 +156,11 @@ class MainViewController: ViewController {
 
     func reconnectLastUsedConnectionWhenPossible() {
         if isConnectionServiceInitialized {
-            reconnectLastUsedConnection()
+            if reconnectLastUsedConnection() {
+                #if os(macOS)
+                (NSApp.delegate as? AppDelegate)?.showMainWindow(self)
+                #endif
+            }
         } else {
             shouldReconnectWhenConnectionServiceInitialized = true
         }
@@ -325,6 +329,9 @@ extension MainViewController: ConnectionServiceInitializationDelegate {
         case .vpnDisabled:
             if shouldReconnectWhenConnectionServiceInitialized {
                 if reconnectLastUsedConnection() {
+                    #if os(macOS)
+                    (NSApp.delegate as? AppDelegate)?.showMainWindow(self)
+                    #endif
                     return
                 }
             }

--- a/EduVPN/Helpers/UserDefaults+Preferences.swift
+++ b/EduVPN/Helpers/UserDefaults+Preferences.swift
@@ -17,6 +17,7 @@ extension UserDefaults {
     private static let isStatusItemInColorKey = "isStatusItemInColor"
     private static let showInDockKey = "showInDock"
     private static let launchAtLoginKey = "launchAtLogin"
+    private static let shouldReconnectOnLaunchAtLoginKey = "shouldReconnectOnLaunchAtLogin"
     #endif
 
     func clearPreferences() {
@@ -108,6 +109,15 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Self.launchAtLoginKey)
+        }
+    }
+
+    var shouldReconnectOnLaunchAtLogin: Bool {
+        get {
+            return bool(forKey: Self.shouldReconnectOnLaunchAtLoginKey)
+        }
+        set {
+            set(newValue, forKey: Self.shouldReconnectOnLaunchAtLoginKey)
         }
     }
 

--- a/EduVPN/Services/Environment.swift
+++ b/EduVPN/Services/Environment.swift
@@ -70,14 +70,12 @@ class Environment {
 
     func instantiateConnectionViewController(
         connectableInstance: ConnectableInstance, serverDisplayInfo: ServerDisplayInfo,
-        initialConnectionFlowContinuationPolicy: ConnectionViewModel.FlowContinuationPolicy,
         authURLTemplate: String? = nil,
-        restoringPreConnectionState: ConnectionAttempt.PreConnectionState? = nil) -> ConnectionViewController {
+        postLoadAction: ConnectionViewController.PostLoadAction) -> ConnectionViewController {
         let parameters = ConnectionViewController.Parameters(
             environment: self, connectableInstance: connectableInstance, serverDisplayInfo: serverDisplayInfo,
             authURLTemplate: authURLTemplate,
-            initialConnectionFlowContinuationPolicy: initialConnectionFlowContinuationPolicy,
-            restoringPreConnectionState: restoringPreConnectionState)
+            postLoadAction: postLoadAction)
         return instantiate(ConnectionViewController.self, identifier: "Connection", parameters: parameters)
     }
 

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -118,7 +118,6 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
         case continueWithProfile(profileId: String)
         case continueWithAnyProfile
         case doNotContinue
-        case notApplicable
     }
 
     private(set) var header: Header {
@@ -386,7 +385,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 return self.continueServerConnectionFlow(
                     profile: profile, from: viewController,
                     serverInfo: serverInfo)
-            case .doNotContinue, .notApplicable:
+            case .doNotContinue:
                 self.internalState = .idle
                 return Promise.value(())
             }

--- a/EduVPN/ViewModels/ConnectionViewModel.swift
+++ b/EduVPN/ViewModels/ConnectionViewModel.swift
@@ -115,6 +115,7 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
     enum FlowContinuationPolicy {
         // After getting the profile list, deciding whether to continue to connect or not
         case continueWithSingleOrLastUsedProfile
+        case continueWithProfile(profileId: String)
         case continueWithAnyProfile
         case doNotContinue
         case notApplicable
@@ -359,6 +360,15 @@ class ConnectionViewModel { // swiftlint:disable:this type_body_length
                 let singleProfile = (profiles.count == 1 ? profiles[0] : nil)
                 let lastUsedProfile = profiles.first(where: { $0.profileId == lastUsedProfileId })
                 guard let profile = (lastUsedProfile ?? singleProfile) else {
+                    self.internalState = .idle
+                    return Promise.value(())
+                }
+                self.delegate?.connectionViewModel(self, willAutomaticallySelectProfileId: profile.profileId)
+                return self.continueServerConnectionFlow(
+                    profile: profile, from: viewController,
+                    serverInfo: serverInfo)
+            case .continueWithProfile(let chosenProfileId):
+                guard let profile = profiles.first(where: { $0.profileId == chosenProfileId }) else {
                     self.internalState = .idle
                     return Promise.value(())
                 }


### PR DESCRIPTION
Fixes #478.

If the Mac was shutdown while the app was running and the VPN was on, the app turns off the VPN and exits without any confirmation alert.

When the Mac is turned on again, and the app is launched-at-login, this PR makes the app connect to the last used connection after going through the API flow (uses the same profile as before).