### PR TITLE
Update WireGuardKit to fix Swift fatal error in tunnel extension

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           xcode-version: latest-stable
       - name: Install Go
-        run: brew install go@1.16
+        run: brew install go@1.19
       - name: Prepare Developer.xcconfig
         run: cp Config/iOS/Developer.xcconfig.eduvpn-template Config/iOS/Developer.xcconfig
       - name: Prepare config.json
@@ -74,7 +74,7 @@ jobs:
       - name: Prepare privacy_statement.json
         run: cp Config/Mac/privacy_statement-eduvpn.json Config/Mac/privacy_statement.json
       - name: Install Go
-        run: brew install go@1.16
+        run: brew install go@1.19
       - name: Run MacOS build
         run: |
           export PATH="/usr/local/opt/go@1.16/bin:/opt/homebrew/opt/go@1.16/bin:$PATH"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Avoid using cached token endpoints from OIDAuthState #487
 - macOS: Point the user to the OS' please-enable-notification prompt #474 
 - Improve error alerts #489
+- Update WireGuardKit to fix crash in tunnel
 
 ## 3.0.6
 

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -406,7 +406,7 @@
 		6F71FBB7249B54490010D0FE /* DiscoveryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryData.swift; sourceTree = "<group>"; };
 		6F71FBBC249CCE980010D0FE /* DiscoveryDataFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscoveryDataFetcher.swift; sourceTree = "<group>"; };
 		6F750C9624975A4300AF2C04 /* eduVPN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = eduVPN.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		6F750D2124975B9B00AF2C04 /* eduVPN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = eduVPN.app; path = .app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F750D2124975B9B00AF2C04 /* eduVPN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = eduVPN.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F7B63EF2500FD7300FB154A /* StatusItemController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusItemController.swift; sourceTree = "<group>"; };
 		6F7B63F125022AAE00FB154A /* LaunchAtLoginHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginHelper.swift; sourceTree = "<group>"; };
 		6F7B643D2502A18C00FB154A /* ConnectionInfoHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionInfoHeaderView.swift; sourceTree = "<group>"; };
@@ -2908,7 +2908,7 @@
 			repositoryURL = "https://git.zx2c4.com/wireguard-apple/";
 			requirement = {
 				kind = revision;
-				revision = 10da5cfdef362889b438cfbeff867a74e6d717fd;
+				revision = ccc7472fd7d1c7c19584e6a30c45a56b8ba57790;
 			};
 		};
 		6FC0638F27B0F0DC00AE25D9 /* XCRemoteSwiftPackageReference "tunnelkit" */ = {

--- a/EduVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EduVPN.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -98,7 +98,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://git.zx2c4.com/wireguard-apple/",
       "state" : {
-        "revision" : "10da5cfdef362889b438cfbeff867a74e6d717fd"
+        "revision" : "ccc7472fd7d1c7c19584e6a30c45a56b8ba57790"
       }
     }
   ],


### PR DESCRIPTION
Update WireGuardKit to include the fix for a fatal error in Swift.